### PR TITLE
fix: sandbox Docker build failing with pnpm symlinks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.git

--- a/apps/api/Dockerfile.sandbox
+++ b/apps/api/Dockerfile.sandbox
@@ -6,7 +6,9 @@ ENV HUSKY=0
 COPY apps/cli/package.json ./
 RUN npm install
 
-COPY apps/cli/ ./
+COPY apps/cli/src ./src
+COPY apps/cli/scripts ./scripts
+COPY apps/cli/tsconfig*.json ./
 RUN npm run build \
   && mkdir -p /tmp/meridian-cli-pack \
   && npm pack --pack-destination /tmp/meridian-cli-pack


### PR DESCRIPTION
## Summary

- Replace blanket `COPY apps/cli/ ./` in `Dockerfile.sandbox` with explicit paths (`src/`, `scripts/`, `tsconfig*.json`) to avoid copying pnpm's symlinked `node_modules` into the container, which collided with the `npm install`'d `node_modules` already present
- Add root `.dockerignore` excluding `node_modules` and `.git`

## Test plan

- [x] `pnpm --filter @meridian/api run build:sandbox` succeeds locally
- [x] All 131 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)