### PR TITLE
fix: sandbox container cannot reach host Keycloak

### DIFF
--- a/apps/api/src/lib/sandbox/docker-runtime.test.ts
+++ b/apps/api/src/lib/sandbox/docker-runtime.test.ts
@@ -209,7 +209,7 @@ describe("createDockerRuntime", () => {
 				"-e",
 				"MERIDIAN_AUTH_CLIENT_ID=meridian-cli",
 				"-e",
-				"MERIDIAN_AUTH_ISSUER=http://localhost:8080/realms/meridian",
+				"MERIDIAN_AUTH_ISSUER=http://host.docker.internal:8080/realms/meridian",
 			]),
 			{ timeout: 30000 },
 			expect.any(Function),

--- a/apps/api/src/lib/sandbox/docker-runtime.ts
+++ b/apps/api/src/lib/sandbox/docker-runtime.ts
@@ -30,7 +30,8 @@ const CONTAINER_HOME = "/sandbox-home";
 const CONTAINER_EXTRA_CA_CERTS_PATH = "/sandbox-extra-ca.pem";
 const DEFAULT_DOCKER_IMAGE = "meridian-chat-sandbox:local";
 const DEFAULT_MERIDIAN_AUTH_CLIENT_ID = "meridian-cli";
-const DEFAULT_MERIDIAN_AUTH_ISSUER = "http://localhost:8080/realms/meridian";
+const DEFAULT_MERIDIAN_AUTH_ISSUER =
+	"http://host.docker.internal:8080/realms/meridian";
 const DEFAULT_SESSION_TTL_MS = 5 * 60 * 1000;
 
 type ContainerState = "missing" | "running" | "stopped";
@@ -219,6 +220,8 @@ export function createDockerRuntime(): SandboxRuntime {
 			"512m",
 			"--pids-limit",
 			"256",
+			"--add-host",
+			"host.docker.internal:host-gateway",
 			"--label",
 			"meridian.chat.runtime=docker",
 			"--label",


### PR DESCRIPTION
## Summary

- Change the default auth issuer for sandbox containers from `localhost:8080` to `host.docker.internal:8080` so the CLI inside the container can reach Keycloak running on the host
- Add `--add-host=host.docker.internal:host-gateway` to container create args for Linux compatibility (Docker Desktop on Mac/Windows provides this automatically)

## Test plan

- [x] All 131 tests pass
- [x] Verified sandbox container can resolve `host.docker.internal` to the host machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)