### PR TITLE
refactor: use async dispose for automatic test cleanup

### DIFF
--- a/apps/cli/tests/helpers/temp-home.ts
+++ b/apps/cli/tests/helpers/temp-home.ts
@@ -7,7 +7,7 @@ export async function createTempHome() {
 
 	return {
 		homeDirectory,
-		async cleanup() {
+		async [Symbol.asyncDispose]() {
 			await rm(homeDirectory, { force: true, recursive: true });
 		},
 		async writeMeridianFile(fileName: string, contents: unknown) {

--- a/apps/cli/tests/unit/commands/auth/login.test.ts
+++ b/apps/cli/tests/unit/commands/auth/login.test.ts
@@ -1,5 +1,5 @@
 import { HttpResponse, http } from "msw";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { DEFAULT_AUTH_CLIENT_ID, DEFAULT_AUTH_ISSUER } from "@/auth/session";
 import { runCli } from "@/cli";
 import { createUnsignedJwt } from "../../../helpers/jwt";
@@ -7,16 +7,9 @@ import { createWritable } from "../../../helpers/streams";
 import { createTempHome } from "../../../helpers/temp-home";
 import { mswServer } from "../../../setup/msw";
 
-const homes: Array<{ cleanup(): Promise<void> }> = [];
-
-afterEach(async () => {
-	await Promise.all(homes.splice(0).map((home) => home.cleanup()));
-});
-
 describe("auth login", () => {
 	it("uses the official Meridian auth defaults when no overrides are set", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		const stdout = createWritable(false);
 		const stderr = createWritable();
 		let requestBody = "";
@@ -61,8 +54,7 @@ describe("auth login", () => {
 	});
 
 	it("prints device details immediately before authentication completes", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		const stdout = createWritable(false);
 		const stderr = createWritable();
 		let tokenPolls = 0;
@@ -132,8 +124,7 @@ describe("auth login", () => {
 	});
 
 	it("completes the device flow and stores credentials", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		const stdout = createWritable(false);
 		const stderr = createWritable();
 		let tokenPolls = 0;
@@ -213,8 +204,7 @@ describe("auth login", () => {
 	});
 
 	it("returns a structured error when the device authorisation request has a transport failure", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		const stdout = createWritable(false);
 		const stderr = createWritable();
 		mswServer.use(
@@ -245,8 +235,7 @@ describe("auth login", () => {
 	});
 
 	it("returns a structured error when token polling has a transport failure", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		const stdout = createWritable(false);
 		const stderr = createWritable();
 		mswServer.use(

--- a/apps/cli/tests/unit/commands/auth/logout.test.ts
+++ b/apps/cli/tests/unit/commands/auth/logout.test.ts
@@ -1,22 +1,15 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { HttpResponse, http } from "msw";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { runCli } from "@/cli";
 import { createWritable } from "../../../helpers/streams";
 import { createTempHome } from "../../../helpers/temp-home";
 import { mswServer } from "../../../setup/msw";
 
-const homes: Array<{ cleanup(): Promise<void> }> = [];
-
-afterEach(async () => {
-	await Promise.all(homes.splice(0).map((home) => home.cleanup()));
-});
-
 describe("auth logout", () => {
 	it("revokes the session and deletes stored credentials", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		await home.writeMeridianFile("credentials.json", {
 			access_token: "access-token",
 			refresh_token: "refresh-token",
@@ -64,8 +57,7 @@ describe("auth logout", () => {
 	});
 
 	it("shows help without deleting stored credentials", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		const credentialsPath = join(
 			home.homeDirectory,
 			".meridian",
@@ -96,8 +88,7 @@ describe("auth logout", () => {
 	});
 
 	it("clears corrupted credentials from local state", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		await mkdir(join(home.homeDirectory, ".meridian"), { recursive: true });
 		await writeFile(
 			join(home.homeDirectory, ".meridian", "credentials.json"),
@@ -124,8 +115,7 @@ describe("auth logout", () => {
 	});
 
 	it("clears a directory-shaped credentials path from local state", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		await mkdir(join(home.homeDirectory, ".meridian"), { recursive: true });
 		await mkdir(join(home.homeDirectory, ".meridian", "credentials.json"));
 		const stdout = createWritable(false);
@@ -149,8 +139,7 @@ describe("auth logout", () => {
 	});
 
 	it("still clears local credentials when remote revoke fails", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		await home.writeMeridianFile("credentials.json", {
 			access_token: "access-token",
 			refresh_token: "refresh-token",

--- a/apps/cli/tests/unit/commands/auth/status.test.ts
+++ b/apps/cli/tests/unit/commands/auth/status.test.ts
@@ -1,23 +1,16 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { HttpResponse, http } from "msw";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { runCli } from "@/cli";
 import { createUnsignedJwt } from "../../../helpers/jwt";
 import { createWritable } from "../../../helpers/streams";
 import { createTempHome } from "../../../helpers/temp-home";
 import { mswServer } from "../../../setup/msw";
 
-const homes: Array<{ cleanup(): Promise<void> }> = [];
-
-afterEach(async () => {
-	await Promise.all(homes.splice(0).map((home) => home.cleanup()));
-});
-
 describe("auth status", () => {
 	it("returns unauthenticated when no credentials are stored", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		const stdout = createWritable(false);
 		const stderr = createWritable();
 
@@ -33,8 +26,7 @@ describe("auth status", () => {
 	});
 
 	it("refreshes expired credentials before reporting status", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		await home.writeMeridianFile("credentials.json", {
 			access_token: "expired-access",
 			refresh_token: "refresh-token",
@@ -79,8 +71,7 @@ describe("auth status", () => {
 	});
 
 	it("returns a structured error when credential refresh hits a transport failure", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		await home.writeMeridianFile("credentials.json", {
 			access_token: "expired-access",
 			refresh_token: "refresh-token",
@@ -116,8 +107,7 @@ describe("auth status", () => {
 	});
 
 	it("returns a structured error when stored credentials are corrupted", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		await home.writeMeridianFile("data.json", {
 			proposal_requests: {},
 			proposals: {},
@@ -145,8 +135,7 @@ describe("auth status", () => {
 	});
 
 	it("returns a structured error when the credentials path is a directory", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		await mkdir(join(home.homeDirectory, ".meridian"), { recursive: true });
 		await mkdir(join(home.homeDirectory, ".meridian", "credentials.json"));
 		const stdout = createWritable(false);

--- a/apps/cli/tests/unit/commands/proposal-requests/create.test.ts
+++ b/apps/cli/tests/unit/commands/proposal-requests/create.test.ts
@@ -1,22 +1,15 @@
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { HttpResponse, http } from "msw";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { runCli } from "@/cli";
 import { createWritable } from "../../../helpers/streams";
 import { createTempHome } from "../../../helpers/temp-home";
 import { mswServer } from "../../../setup/msw";
 
-const homes: Array<{ cleanup(): Promise<void> }> = [];
-
-afterEach(async () => {
-	await Promise.all(homes.splice(0).map((home) => home.cleanup()));
-});
-
 describe("proposal-requests create", () => {
 	it("accepts the spaced version option form", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		const inputFile = join(home.homeDirectory, "broadband.json");
 		await writeFile(
 			inputFile,
@@ -74,8 +67,7 @@ describe("proposal-requests create", () => {
 	});
 
 	it("creates a proposal request from a valid json file", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		const inputFile = join(home.homeDirectory, "broadband.json");
 		await writeFile(
 			inputFile,
@@ -130,8 +122,7 @@ describe("proposal-requests create", () => {
 	});
 
 	it("rejects invalid input files with validation issues", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		const inputFile = join(home.homeDirectory, "invalid.json");
 		await writeFile(
 			inputFile,
@@ -185,8 +176,7 @@ describe("proposal-requests create", () => {
 	});
 
 	it("returns a structured error when the input file contains invalid json", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		const inputFile = join(home.homeDirectory, "invalid-json.json");
 		await writeFile(inputFile, "{invalid json");
 		await home.writeMeridianFile("credentials.json", {
@@ -224,8 +214,7 @@ describe("proposal-requests create", () => {
 	});
 
 	it("returns a structured error when the input file cannot be read", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		const inputFile = join(home.homeDirectory, "missing.json");
 		await home.writeMeridianFile("credentials.json", {
 			access_token: "access-token",
@@ -262,8 +251,7 @@ describe("proposal-requests create", () => {
 	});
 
 	it("requires authentication before creating a proposal request", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		const inputFile = join(home.homeDirectory, "broadband.json");
 		await writeFile(
 			inputFile,
@@ -302,8 +290,7 @@ describe("proposal-requests create", () => {
 	});
 
 	it("refreshes expired credentials before creating a proposal request", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		const inputFile = join(home.homeDirectory, "broadband.json");
 		await writeFile(
 			inputFile,

--- a/apps/cli/tests/unit/commands/proposals/create.test.ts
+++ b/apps/cli/tests/unit/commands/proposals/create.test.ts
@@ -1,20 +1,13 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { runCli } from "@/cli";
 import { createWritable } from "../../../helpers/streams";
 import { createTempHome } from "../../../helpers/temp-home";
 
-const homes: Array<{ cleanup(): Promise<void> }> = [];
-
-afterEach(async () => {
-	await Promise.all(homes.splice(0).map((home) => home.cleanup()));
-});
-
 describe("proposals create", () => {
 	it("creates a proposal and generates mock results", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		await home.writeMeridianFile("credentials.json", {
 			access_token: "access-token",
 			refresh_token: "refresh-token",
@@ -92,8 +85,7 @@ describe("proposals create", () => {
 	});
 
 	it("errors when the proposal request does not exist", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		await home.writeMeridianFile("credentials.json", {
 			access_token: "access-token",
 			refresh_token: "refresh-token",
@@ -122,8 +114,7 @@ describe("proposals create", () => {
 	});
 
 	it("stores a single result entity per proposal", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		await home.writeMeridianFile("credentials.json", {
 			access_token: "access-token",
 			user: "john.doe@example.com",

--- a/apps/cli/tests/unit/commands/results/get.test.ts
+++ b/apps/cli/tests/unit/commands/results/get.test.ts
@@ -1,15 +1,9 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { runCli } from "@/cli";
 import { createWritable } from "../../../helpers/streams";
 import { createTempHome } from "../../../helpers/temp-home";
-
-const homes: Array<{ cleanup(): Promise<void> }> = [];
-
-afterEach(async () => {
-	await Promise.all(homes.splice(0).map((home) => home.cleanup()));
-});
 
 function createBroadbandResult() {
 	return {
@@ -130,7 +124,6 @@ async function seedHomeWithResult(
 		| ReturnType<typeof createTravelResult>,
 ) {
 	const home = await createTempHome();
-	homes.push(home);
 	await home.writeMeridianFile("credentials.json", {
 		access_token: "access-token",
 		user: "john.doe@example.com",
@@ -169,7 +162,10 @@ async function seedHomeWithResult(
 
 describe("results get", () => {
 	it("returns a single result entity in json mode", async () => {
-		const home = await seedHomeWithResult("broadband", createBroadbandResult());
+		await using home = await seedHomeWithResult(
+			"broadband",
+			createBroadbandResult(),
+		);
 		const stdout = createWritable(false);
 		const stderr = createWritable();
 
@@ -247,7 +243,10 @@ describe("results get", () => {
 	});
 
 	it("prints a human-friendly broadband table from offerings", async () => {
-		const home = await seedHomeWithResult("broadband", createBroadbandResult());
+		await using home = await seedHomeWithResult(
+			"broadband",
+			createBroadbandResult(),
+		);
 		const stdout = createWritable(true);
 		const stderr = createWritable();
 
@@ -271,7 +270,7 @@ describe("results get", () => {
 	});
 
 	it("prints a travel-specific human-friendly table from offerings", async () => {
-		const home = await seedHomeWithResult("travel", createTravelResult());
+		await using home = await seedHomeWithResult("travel", createTravelResult());
 		const stdout = createWritable(true);
 		const stderr = createWritable();
 
@@ -293,8 +292,7 @@ describe("results get", () => {
 	});
 
 	it("returns a structured error when the local data store is corrupted", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		await home.writeMeridianFile("credentials.json", {
 			access_token: "access-token",
 			user: "john.doe@example.com",
@@ -327,8 +325,7 @@ describe("results get", () => {
 	});
 
 	it("returns a structured error when the data store path is a directory", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		await home.writeMeridianFile("credentials.json", {
 			access_token: "access-token",
 			user: "john.doe@example.com",

--- a/apps/cli/tests/unit/store/credentials.test.ts
+++ b/apps/cli/tests/unit/store/credentials.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { resolveDependencies } from "@/runtime";
 import {
 	deleteCredentials,
@@ -7,16 +7,9 @@ import {
 } from "@/store/credentials";
 import { createTempHome } from "../../helpers/temp-home";
 
-const homes: Array<{ cleanup(): Promise<void>; homeDirectory: string }> = [];
-
-afterEach(async () => {
-	await Promise.all(homes.splice(0).map((home) => home.cleanup()));
-});
-
 describe("credentials store", () => {
 	it("writes then reads credentials", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		const dependencies = resolveDependencies({
 			homeDirectory: home.homeDirectory,
 		});
@@ -39,8 +32,7 @@ describe("credentials store", () => {
 	});
 
 	it("returns null when no credentials exist", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		const dependencies = resolveDependencies({
 			homeDirectory: home.homeDirectory,
 		});
@@ -51,8 +43,7 @@ describe("credentials store", () => {
 	});
 
 	it("deletes stored credentials", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		const dependencies = resolveDependencies({
 			homeDirectory: home.homeDirectory,
 		});

--- a/apps/cli/tests/unit/store/data.test.ts
+++ b/apps/cli/tests/unit/store/data.test.ts
@@ -1,18 +1,11 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { resolveDependencies } from "@/runtime";
 import { readDataStore, writeDataStore } from "@/store/data";
 import { createTempHome } from "../../helpers/temp-home";
 
-const homes: Array<{ cleanup(): Promise<void>; homeDirectory: string }> = [];
-
-afterEach(async () => {
-	await Promise.all(homes.splice(0).map((home) => home.cleanup()));
-});
-
 describe("data store", () => {
 	it("returns an empty store when the file does not exist", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		const dependencies = resolveDependencies({
 			homeDirectory: home.homeDirectory,
 		});
@@ -27,8 +20,7 @@ describe("data store", () => {
 	});
 
 	it("persists the data store to disk", async () => {
-		const home = await createTempHome();
-		homes.push(home);
+		await using home = await createTempHome();
 		const dependencies = resolveDependencies({
 			homeDirectory: home.homeDirectory,
 		});


### PR DESCRIPTION
## Summary
- Add `Symbol.asyncDispose` to `createTempHome()` so tests can use `await using` for automatic cleanup
- Remove manual cleanup boilerplate (homes array, afterEach, homes.push) from 8 test files
- Net reduction of ~75 lines of boilerplate

## Test plan
- [x] All 72 CLI tests pass
- [x] Full workspace lint, typecheck, and test suite pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)