### PR TITLE
fix(chat): minimize debug trace exports

### DIFF
--- a/apps/chat/src/components/chat.tsx
+++ b/apps/chat/src/components/chat.tsx
@@ -5,11 +5,7 @@ import {
 	type RuntimeEventEnvelope,
 } from "@meridian/contracts/runtime-events";
 import { startTransition, useEffect, useRef, useState } from "react";
-import {
-	buildDebugTrace,
-	type ChatTurnTrace,
-	createTurnTrace,
-} from "@/lib/chat/debug-trace";
+import { buildCopyDebugTrace } from "@/lib/chat/debug-trace";
 import {
 	mapRuntimeToolEventToViewModel,
 	mapRuntimeTurnToolCallsToViewModels,
@@ -66,7 +62,6 @@ export function Chat() {
 	const [messages, setMessages] = useState<ChatMessageType[]>([]);
 	const [loading, setLoading] = useState(false);
 	const [sessionId, setSessionId] = useState<string | null>(null);
-	const [turnLogs, setTurnLogs] = useState<ChatTurnTrace[]>([]);
 	const [traceStatus, setTraceStatus] = useState<string | null>(null);
 	const [debugStreamDelayMs, setDebugStreamDelayMs] = useState(0);
 	const scrollRef = useRef<HTMLDivElement>(null);
@@ -115,20 +110,6 @@ export function Chat() {
 		shouldAutoScrollRef.current = true;
 		setMessages([...conversationMessages, assistantMessage]);
 		setLoading(true);
-
-		const runtimeEvents: RuntimeEventEnvelope[] = [];
-
-		function recordTurn(response: NonNullable<ChatTurnTrace["response"]>) {
-			setTurnLogs((prev) => [
-				...prev,
-				createTurnTrace({
-					response,
-					runtimeEvents,
-					sessionId: activeSessionId,
-					userMessageId: userMessage.id,
-				}),
-			]);
-		}
 
 		let streamedContent = "";
 		let streamedToolCalls: ToolCallInfo[] = [];
@@ -179,8 +160,6 @@ export function Chat() {
 			}
 
 			await readChatStream(res, (event) => {
-				runtimeEvents.push(event);
-
 				if (event.type === "assistant.delta") {
 					streamedContent += event.payload.delta;
 					scheduleFlush();
@@ -206,10 +185,6 @@ export function Chat() {
 					streamedToolCalls = mapRuntimeTurnToolCallsToViewModels(
 						event.payload.toolCalls,
 					);
-					recordTurn({
-						content: event.payload.content,
-						toolCalls: streamedToolCalls,
-					});
 
 					if (frameId !== null) {
 						window.cancelAnimationFrame(frameId);
@@ -231,9 +206,6 @@ export function Chat() {
 			}
 
 			console.error("Chat API error:", error);
-			recordTurn({
-				error: error instanceof Error ? error.message : String(error),
-			});
 
 			startTransition(() => {
 				setMessages((prev) =>
@@ -252,10 +224,9 @@ export function Chat() {
 	}
 
 	async function handleCopyTrace() {
-		const trace = buildDebugTrace({
+		const trace = buildCopyDebugTrace({
 			messages,
 			sessionId,
-			turnLogs,
 		});
 
 		try {
@@ -268,10 +239,9 @@ export function Chat() {
 	}
 
 	function handleDownloadTrace() {
-		const trace = buildDebugTrace({
+		const trace = buildCopyDebugTrace({
 			messages,
 			sessionId,
-			turnLogs,
 		});
 		const blob = new Blob([JSON.stringify(trace, null, 2)], {
 			type: "application/json",

--- a/apps/chat/src/lib/chat/debug-trace.test.ts
+++ b/apps/chat/src/lib/chat/debug-trace.test.ts
@@ -1,6 +1,10 @@
 import type { RuntimeEventEnvelope } from "@meridian/contracts/runtime-events";
 import { describe, expect, it } from "vitest";
-import { buildDebugTrace, createTurnTrace } from "@/lib/chat/debug-trace";
+import {
+	buildCopyDebugTrace,
+	buildDebugTrace,
+	createTurnTrace,
+} from "@/lib/chat/debug-trace";
 import type { ChatMessageViewModel } from "@/lib/chat/view-models";
 
 const runtimeEvents: RuntimeEventEnvelope[] = [
@@ -83,5 +87,60 @@ describe("chat debug trace", () => {
 				turnLogs: [turnTrace],
 			}).turnLogs[0]?.runtimeEvents,
 		).toEqual(runtimeEvents);
+	});
+
+	it("builds a compact copy trace with messages and tool calls only", () => {
+		const copyTrace = buildCopyDebugTrace({
+			messages: [
+				{
+					content: "Find me a deal",
+					id: "msg-user-1",
+					role: "user",
+					timestamp: "2026-03-10T12:00:00.000Z",
+				},
+				{
+					content: "I found 2 offers worth comparing.",
+					id: "msg-assistant-1",
+					role: "assistant",
+					timestamp: "2026-03-10T12:00:02.000Z",
+					toolCalls: [
+						{
+							id: "tool-1",
+							input: '{"path":"offers.json"}',
+							name: "read_file",
+							result: '{"offers":2}',
+							status: "completed",
+						},
+					],
+				},
+			] satisfies ChatMessageViewModel[],
+			sessionId: "session-123",
+		});
+
+		expect(copyTrace).toMatchObject({
+			sessionId: "session-123",
+			messages: [
+				{
+					content: "Find me a deal",
+					id: "msg-user-1",
+					role: "user",
+				},
+				{
+					content: "I found 2 offers worth comparing.",
+					id: "msg-assistant-1",
+					role: "assistant",
+					toolCalls: [
+						{
+							id: "tool-1",
+							input: '{"path":"offers.json"}',
+							name: "read_file",
+							result: '{"offers":2}',
+							status: "completed",
+						},
+					],
+				},
+			],
+		});
+		expect(copyTrace).not.toHaveProperty("turnLogs");
 	});
 });

--- a/apps/chat/src/lib/chat/debug-trace.ts
+++ b/apps/chat/src/lib/chat/debug-trace.ts
@@ -2,6 +2,11 @@ import type { RuntimeEventEnvelope } from "@meridian/contracts/runtime-events";
 import type { ToolCallViewModel } from "./contracts";
 import type { ChatMessageViewModel } from "./view-models";
 
+type DebugTraceExportArgs = {
+	messages: ChatMessageViewModel[];
+	sessionId: string | null;
+};
+
 export type ChatTurnTrace = {
 	at: string;
 	/** ID of the user message that triggered this turn. */
@@ -44,9 +49,7 @@ export function buildDebugTrace({
 	messages,
 	sessionId,
 	turnLogs,
-}: {
-	messages: ChatMessageViewModel[];
-	sessionId: string | null;
+}: DebugTraceExportArgs & {
 	turnLogs: ChatTurnTrace[];
 }) {
 	return {
@@ -54,5 +57,16 @@ export function buildDebugTrace({
 		sessionId,
 		messages,
 		turnLogs,
+	};
+}
+
+export function buildCopyDebugTrace({
+	messages,
+	sessionId,
+}: DebugTraceExportArgs) {
+	return {
+		exportedAt: new Date().toISOString(),
+		sessionId,
+		messages,
 	};
 }

--- a/apps/chat/tests/ui/chat.debug.test.tsx
+++ b/apps/chat/tests/ui/chat.debug.test.tsx
@@ -1,5 +1,5 @@
 import { http } from "msw";
-import { describe, expect } from "vitest";
+import { describe, expect, vi } from "vitest";
 import {
 	createChatEventFactory,
 	createChatStreamResponse,
@@ -34,5 +34,164 @@ describe("Chat UI - debug controls", () => {
 		expect(requestHeaders).toMatchObject({
 			"x-meridian-debug-stream-delay-ms": "120",
 		});
+	});
+
+	test("copies a compact debug trace with conversation messages and tool calls", async ({
+		chatPage,
+	}) => {
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		const eventFactory = createChatEventFactory();
+
+		Object.defineProperty(window.navigator, "clipboard", {
+			configurable: true,
+			value: {
+				writeText,
+			},
+		});
+
+		browserWorker.use(
+			http.post("http://localhost:3201/api/chat", () =>
+				createChatStreamResponse([
+					eventFactory.create("assistant.delta", {
+						delta: "Working through the options...",
+					}),
+					eventFactory.create("tool.completed", {
+						toolCall: {
+							id: "tool-1",
+							input: '{"path":"offers.json"}',
+							name: "read_file",
+							output: '{"offers":2}',
+						},
+					}),
+					eventFactory.create("turn.completed", {
+						content: "I found 2 offers worth comparing.",
+						toolCalls: [
+							{
+								id: "tool-1",
+								input: '{"path":"offers.json"}',
+								name: "read_file",
+								output: '{"offers":2}',
+								state: "completed",
+							},
+						],
+					}),
+				]),
+			),
+		);
+
+		await chatPage.sendMessage("Find me a deal");
+		await chatPage.expectAssistantResponse("I found 2 offers worth comparing.");
+		await chatPage.getCopyTraceButton().click();
+
+		expect(writeText).toHaveBeenCalledTimes(1);
+
+		const copiedTrace = JSON.parse(writeText.mock.calls[0]?.[0] ?? "null");
+		expect(copiedTrace).toMatchObject({
+			sessionId: expect.any(String),
+			messages: [
+				{
+					content: "Find me a deal",
+					role: "user",
+				},
+				{
+					content: "I found 2 offers worth comparing.",
+					role: "assistant",
+					toolCalls: [
+						{
+							id: "tool-1",
+							input: '{"path":"offers.json"}',
+							name: "read_file",
+							result: '{"offers":2}',
+							status: "completed",
+						},
+					],
+				},
+			],
+		});
+		expect(copiedTrace).not.toHaveProperty("turnLogs");
+	});
+
+	test("downloads a compact debug trace with conversation messages and tool calls", async ({
+		chatPage,
+	}) => {
+		const createObjectUrl = vi
+			.spyOn(URL, "createObjectURL")
+			.mockReturnValue("blob:trace");
+		const revokeObjectUrl = vi
+			.spyOn(URL, "revokeObjectURL")
+			.mockImplementation(() => {});
+		const anchorClick = vi
+			.spyOn(HTMLAnchorElement.prototype, "click")
+			.mockImplementation(() => {});
+		const eventFactory = createChatEventFactory();
+
+		browserWorker.use(
+			http.post("http://localhost:3201/api/chat", () =>
+				createChatStreamResponse([
+					eventFactory.create("assistant.delta", {
+						delta: "Working through the options...",
+					}),
+					eventFactory.create("tool.completed", {
+						toolCall: {
+							id: "tool-1",
+							input: '{"path":"offers.json"}',
+							name: "read_file",
+							output: '{"offers":2}',
+						},
+					}),
+					eventFactory.create("turn.completed", {
+						content: "I found 2 offers worth comparing.",
+						toolCalls: [
+							{
+								id: "tool-1",
+								input: '{"path":"offers.json"}',
+								name: "read_file",
+								output: '{"offers":2}',
+								state: "completed",
+							},
+						],
+					}),
+				]),
+			),
+		);
+
+		await chatPage.sendMessage("Find me a deal");
+		await chatPage.expectAssistantResponse("I found 2 offers worth comparing.");
+		await chatPage.getDownloadJsonButton().click();
+
+		expect(createObjectUrl).toHaveBeenCalledTimes(1);
+		expect(anchorClick).toHaveBeenCalledTimes(1);
+		expect(revokeObjectUrl).toHaveBeenCalledWith("blob:trace");
+
+		const exportedBlob = createObjectUrl.mock.calls[0]?.[0];
+		expect(exportedBlob).toBeInstanceOf(Blob);
+		if (!(exportedBlob instanceof Blob)) {
+			throw new Error("Expected debug trace download to be a Blob");
+		}
+
+		const downloadedTrace = JSON.parse(await exportedBlob.text());
+		expect(downloadedTrace).toMatchObject({
+			sessionId: expect.any(String),
+			messages: [
+				{
+					content: "Find me a deal",
+					role: "user",
+				},
+				{
+					content: "I found 2 offers worth comparing.",
+					role: "assistant",
+					toolCalls: [
+						{
+							id: "tool-1",
+							input: '{"path":"offers.json"}',
+							name: "read_file",
+							result: '{"offers":2}',
+							status: "completed",
+						},
+					],
+				},
+			],
+		});
+		expect(downloadedTrace).not.toHaveProperty("turnLogs");
 	});
 });


### PR DESCRIPTION
## Summary
- export a compact debug trace for both copy and download actions
- remove verbose runtime event turn logs from chat trace exports
- add unit and browser coverage for the compact payload

## Testing
- pnpm --filter @meridian/chat test -- --project unit src/lib/chat/debug-trace.test.ts
- pnpm --filter @meridian/chat test -- --project browser tests/ui/chat.debug.test.tsx
- pnpm lint
- pnpm typecheck