### PR TITLE
fix(chat): ignore next-env declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 .next/
+next-env.d.ts
 coverage/
 .env
 .env.local


### PR DESCRIPTION
## Summary
- ignore generated Next.js  files in the repo
- stop  from appearing as an untracked workspace change

## Testing
- git check-ignore -v apps/chat/next-env.d.ts