### PR TITLE
fix(api): tighten agent prompt follow-ups

### DIFF
--- a/apps/api/sandbox-instructions.md
+++ b/apps/api/sandbox-instructions.md
@@ -6,15 +6,19 @@ Rules:
 
 - For any product, proposal, or comparison question, use the runtime tools and installed CLIs first. Do not answer from world knowledge.
 - Try to fulfill the user's request end to end with the available tools rather than stopping to ask for permission for routine prerequisite steps.
-- Prefer the smallest read-only command that moves the task forward.
-- When unsure of a command's shape, check `--help` before running it.
 - Use the product schema to determine what fields are required. Do not guess.
+- Use the schema to distinguish required fields from optional preferences. Do not ask the user to confirm missing optional fields; treat them as no preference unless they volunteer them.
+- In user-facing replies, describe fields in plain English. Do not mirror raw schema property names unless the user explicitly wants the schema.
+- Do not ask the user to reply in JSON unless the workflow actually requires them to paste JSON.
+- For a new runtime or unfamiliar command, inspect `--help` before making assumptions.
 
 Authentication:
 
 - Check auth early with `meridian auth status --json`.
-- If unauthenticated, start `meridian auth login --json`.
-- Default to waiting for command exit so you receive the full JSON result.
-- `meridian auth login --json` emits NDJSON events. A good orchestration pattern is to start it with `waitFor: "first-stdout-line"` and `keepAlive: true`, capture the pending event, continue with other useful read-only steps, then inspect or wait on the returned background command.
+- If unauthenticated, start `meridian auth login --json` with `waitFor: "first-stdout-line"` and `keepAlive: true`.
+- Starting the login flow is a routine prerequisite step. Do not ask whether to start it when the user's task depends on authenticated commands.
+- `meridian auth login --json` emits NDJSON events. Capture the pending event with the verification URL and user code, continue any useful read-only work, then inspect or wait on the returned background command.
+- On later turns, if login may have completed in the background or the user says they finished it, check `meridian auth status --json` again before asking them to log in. If needed, inspect or wait on the existing background command for confirmation.
+- For other commands, default to waiting for command exit so you receive the full JSON result.
 - Only use `waitFor: "first-stdout-line"` with `keepAlive: true` for device-flow login or another command that is known to stay running and emit a useful first line early.
 - Do not use `first-stdout-line` for `proposal-requests create`, `proposals create`, or `results get`; these should be awaited to completion.

--- a/apps/api/src/lib/agent/service.test.ts
+++ b/apps/api/src/lib/agent/service.test.ts
@@ -101,4 +101,32 @@ describe("agent service", () => {
 			toolCalls: [],
 		});
 	});
+
+	it("excludes reasoning blocks from streamed assistant text", async () => {
+		const runtime = createInMemorySandboxRuntime();
+		const createRunner = createScriptedAgentRunner(async function* () {
+			yield {
+				content: [
+					{ reasoning: "I checked auth first.", type: "reasoning" },
+					{
+						text: "Please complete sign-in and send your postcode.",
+						type: "text",
+					},
+				],
+				messageType: "ai",
+				mode: "messages",
+			};
+		});
+		const service = createAgentService({ createRunner, runtime });
+
+		await expect(
+			service.streamConversation({
+				message: "Compare broadband for me",
+				sessionId: "session-a",
+			}),
+		).resolves.toEqual({
+			content: "Please complete sign-in and send your postcode.",
+			toolCalls: [],
+		});
+	});
 });

--- a/apps/api/src/lib/agent/tools.test.ts
+++ b/apps/api/src/lib/agent/tools.test.ts
@@ -11,7 +11,7 @@ vi.mock("langchain", () => ({
 	},
 }));
 
-import { createRuntimeAgentTools } from "@/lib/agent/tools";
+import { createRuntimeAgentTools, extractTextContent } from "@/lib/agent/tools";
 
 function createMockRuntime(): SandboxRuntime {
 	return {
@@ -107,5 +107,14 @@ describe("createRuntimeAgentTools", () => {
 			"read_file",
 			"write_file",
 		]);
+	});
+
+	it("extracts visible text content without including reasoning blocks", () => {
+		expect(
+			extractTextContent([
+				{ reasoning: "Checked auth and schema.", type: "reasoning" },
+				{ text: "Please sign in and send your postcode.", type: "text" },
+			]),
+		).toBe("Please sign in and send your postcode.");
 	});
 });

--- a/apps/api/src/lib/agent/tools.ts
+++ b/apps/api/src/lib/agent/tools.ts
@@ -201,14 +201,6 @@ export function extractTextContent(content: unknown): string {
 				return item.text;
 			}
 
-			if (
-				item.type === "reasoning" &&
-				"reasoning" in item &&
-				typeof item.reasoning === "string"
-			) {
-				return item.reasoning;
-			}
-
 			return "";
 		})
 		.join("");

--- a/apps/api/src/lib/system-prompt.test.ts
+++ b/apps/api/src/lib/system-prompt.test.ts
@@ -26,9 +26,42 @@ describe("system prompt contract", () => {
 		);
 	});
 
+	it("tells the agent to treat routine prerequisites like auth startup as part of fulfilling the request", () => {
+		expect(systemPrompt).toContain(
+			"Treat routine prerequisites such as starting authentication as part of fulfilling the request, including on follow-up turns where the user is only providing missing details.",
+		);
+	});
+
+	it("tells the agent to re-check changing prerequisites and keep requests user-friendly", () => {
+		expect(systemPrompt).toContain(
+			"On follow-up turns, if a prerequisite may have changed state in the background, re-check it before asking the user to repeat or confirm it.",
+		);
+		expect(systemPrompt).toContain(
+			"Use plain language for user-facing requests. Translate schema field names into natural wording instead of echoing raw property names.",
+		);
+		expect(systemPrompt).toContain(
+			"Do not ask the user to reply in JSON unless they asked for that format or the task truly requires pasted JSON.",
+		);
+		expect(systemPrompt).toContain(
+			"If the user has already provided all required fields, proceed with sensible defaults for optional fields instead of asking them to confirm that they have no preferences.",
+		);
+	});
+
 	it("tells the agent not to claim background work is running without a live command id", () => {
 		expect(systemPrompt).toContain(
 			"Do not claim a task is still running unless you actually have a live `backgroundCommandId`.",
+		);
+	});
+
+	it("tells the agent to lead with the user-facing outcome and keep replies cohesive", () => {
+		expect(systemPrompt).toContain(
+			"Lead with the result, decision, or required next action.",
+		);
+		expect(systemPrompt).toContain(
+			"Mention tool use or exploration only when it materially changes what the user needs to know.",
+		);
+		expect(systemPrompt).toContain(
+			"Your final reply for each turn should read as one cohesive response, not a chronological log of tool calls or repeated restatements.",
 		);
 	});
 });

--- a/apps/api/src/lib/system-prompt.ts
+++ b/apps/api/src/lib/system-prompt.ts
@@ -27,11 +27,19 @@ export const systemPrompt = `You are the orchestrator agent operating inside a s
 
 ## User interaction
 
-- Be explicit about what you discovered and what you are doing.
+- Lead with the result, decision, or required next action.
+- Mention tool use or exploration only when it materially changes what the user needs to know.
+- Your final reply for each turn should read as one cohesive response, not a chronological log of tool calls or repeated restatements.
 - Ask the user for required information instead of inventing missing details.
 - Default to executing routine prerequisite steps when they are necessary to complete the request, low risk, and reversible.
+- Treat routine prerequisites such as starting authentication as part of fulfilling the request, including on follow-up turns where the user is only providing missing details.
+- On follow-up turns, if a prerequisite may have changed state in the background, re-check it before asking the user to repeat or confirm it.
 - Pause and ask the user only when required information is missing, an action has meaningful external side effects or destructive consequences, or the user must choose among materially different valid paths.
 - When a prerequisite requires user interaction, initiate it, present the required instructions clearly, and continue any other useful work that does not depend on the user's input yet.
+- If the user must complete a prerequisite and also provide missing inputs, mention each item once and avoid repeating the same link, code, or request in different wording.
+- Use plain language for user-facing requests. Translate schema field names into natural wording instead of echoing raw property names.
+- Do not ask the user to reply in JSON unless they asked for that format or the task truly requires pasted JSON.
+- If the user has already provided all required fields, proceed with sensible defaults for optional fields instead of asking them to confirm that they have no preferences.
 - When commands fail, explain the failure in plain language and recover by exploring or asking a focused follow-up question.
 - When presenting results, format them clearly.
 


### PR DESCRIPTION
## Summary
- strip reasoning blocks from visible assistant output
- tighten prompt and runtime instructions for auth follow-ups and plain-language replies
- add regression coverage for prompt contract and reasoning filtering

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test