### PR TITLE
refactor(api): move sessionId to header, drop x- prefix

### DIFF
--- a/apps/api/docs/agent-reference.md
+++ b/apps/api/docs/agent-reference.md
@@ -42,9 +42,9 @@ Validation failures are different from streamed turn failures.
 
 ### Session Model
 
-The caller must provide `sessionId` on every request.
+The caller must provide the `Session-Id` header on every request.
 
-- `sessionId` must match `^[A-Za-z0-9_-]+$`
+- `Session-Id` must match `^[A-Za-z0-9_-]+$`
 - empty values are rejected
 - the same `sessionId` continues the same conversation history
 - a different `sessionId` starts a new conversation
@@ -81,29 +81,31 @@ Submits one user message to the current session and streams runtime events for t
 ```bash
 curl -N http://localhost:3000/api/chat \
   -H 'Content-Type: application/json' \
+  -H 'Session-Id: session-123' \
   -d '{
-    "sessionId": "session-123",
     "message": "Find me a broadband quote"
   }'
 ```
+
+Required headers:
+
+- `Session-Id`: required string used to continue or create a conversation session (must match `^[A-Za-z0-9_-]+$`)
 
 Request body:
 
 ```json
 {
-  "sessionId": "session-123",
   "message": "Find me a broadband quote"
 }
 ```
 
 Fields:
 
-- `sessionId`: required string used to continue or create a conversation session
 - `message`: required non-empty user message
 
 Behaviour:
 
-- validates `sessionId` and `message`
+- validates the `Session-Id` header and `message`
 - loads any stored conversation history for the session
 - appends the new user message to the history sent to the agent
 - streams runtime events as the turn progresses

--- a/apps/api/src/routes/chat.debug-stream.integration.test.ts
+++ b/apps/api/src/routes/chat.debug-stream.integration.test.ts
@@ -61,7 +61,7 @@ describe("POST /api/chat integration - debug stream delay", () => {
 					},
 					{
 						headers: {
-							"x-meridian-debug-stream-delay-ms": "50",
+							"meridian-debug-stream-delay-ms": "50",
 						},
 					},
 				),

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -17,17 +17,17 @@ import {
 	mapErrorToRuntimeEvent,
 } from "@/lib/runtime-events/agent-mappers";
 import type { SandboxRuntime } from "@/lib/sandbox/runtime";
-import { SESSION_ID_PATTERN } from "@/lib/sandbox/runtime-shared";
 import { getSandboxRuntime } from "@/lib/sandbox/singleton";
 
 const MAX_DEBUG_DELAY_MS = 1000;
 const encoder = new TextEncoder();
 
+const sessionIdSchema = z
+	.string()
+	.min(1, "Missing or invalid sessionId.")
+	.regex(/^[A-Za-z0-9_-]+$/, "Missing or invalid sessionId.");
+
 const chatRequestSchema = z.object({
-	sessionId: z
-		.string()
-		.nonempty("Missing or invalid sessionId.")
-		.regex(SESSION_ID_PATTERN, "Missing or invalid sessionId."),
 	message: z
 		.string()
 		.nonempty("Missing or invalid message.")
@@ -48,14 +48,24 @@ export function createChatRoute({
 	sleep = delay,
 }: ChatRouteDependencies = {}) {
 	return async (request: Request) => {
-		const result = chatRequestSchema.safeParse(await request.json());
+		const sessionIdResult = sessionIdSchema.safeParse(
+			request.headers.get("session-id"),
+		);
 
-		if (!result.success) {
-			const errors = result.error.issues.map((issue) => issue.message);
+		if (!sessionIdResult.success) {
+			const errors = sessionIdResult.error.issues.map((issue) => issue.message);
 			return Response.json({ errors }, { status: 400 });
 		}
 
-		const { message, sessionId } = result.data;
+		const bodyResult = chatRequestSchema.safeParse(await request.json());
+
+		if (!bodyResult.success) {
+			const errors = bodyResult.error.issues.map((issue) => issue.message);
+			return Response.json({ errors }, { status: 400 });
+		}
+
+		const sessionId = sessionIdResult.data;
+		const { message } = bodyResult.data;
 		const debugDelayMs = getDebugDelayMs(request.headers);
 		const runtime = getRuntime();
 		const agentService = createAgentService({ runtime });
@@ -135,7 +145,7 @@ export function createChatRoute({
 export const handleChat = createChatRoute();
 
 function getDebugDelayMs(headers: Headers) {
-	const raw = headers.get("x-meridian-debug-stream-delay-ms");
+	const raw = headers.get("meridian-debug-stream-delay-ms");
 	if (!raw) {
 		return 0;
 	}

--- a/apps/api/tests/support/chat-route.ts
+++ b/apps/api/tests/support/chat-route.ts
@@ -10,9 +10,10 @@ export function createChatRequest(
 	},
 ) {
 	return new Request("http://localhost/api/chat", {
-		body: JSON.stringify(body),
+		body: JSON.stringify({ message: body.message }),
 		headers: {
 			"Content-Type": "application/json",
+			"session-id": body.sessionId,
 			...(options?.headers ?? {}),
 		},
 		method: "POST",

--- a/apps/chat/src/components/chat.tsx
+++ b/apps/chat/src/components/chat.tsx
@@ -147,11 +147,11 @@ export function Chat() {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					"x-meridian-debug-stream-delay-ms": String(debugStreamDelayMs),
+					"session-id": activeSessionId,
+					"meridian-debug-stream-delay-ms": String(debugStreamDelayMs),
 				},
 				body: JSON.stringify({
 					message: content,
-					sessionId: activeSessionId,
 				}),
 			});
 

--- a/apps/chat/src/lib/chat/contracts.ts
+++ b/apps/chat/src/lib/chat/contracts.ts
@@ -10,5 +10,4 @@ export interface ToolCallViewModel {
 
 export interface ChatRequest {
 	message: string;
-	sessionId?: string;
 }

--- a/apps/chat/tests/ui/chat.debug.test.tsx
+++ b/apps/chat/tests/ui/chat.debug.test.tsx
@@ -32,7 +32,7 @@ describe("Chat UI - debug controls", () => {
 		await chatPage.expectAssistantResponse("Done.");
 
 		expect(requestHeaders).toMatchObject({
-			"x-meridian-debug-stream-delay-ms": "120",
+			"meridian-debug-stream-delay-ms": "120",
 		});
 	});
 

--- a/apps/chat/tests/ui/chat.submission.test.tsx
+++ b/apps/chat/tests/ui/chat.submission.test.tsx
@@ -57,11 +57,11 @@ describe("Chat UI - submission and streaming", () => {
 		await chatPage.expectMessageInputValue("");
 		expect(requestBody).toMatchObject({
 			message: "Find me a deal",
-			sessionId: expect.any(String),
 		});
 		expect(requestHeaders).toMatchObject({
 			"content-type": "application/json",
-			"x-meridian-debug-stream-delay-ms": "0",
+			"session-id": expect.any(String),
+			"meridian-debug-stream-delay-ms": "0",
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Moves `sessionId` from the request body to a `session-id` header — it's request metadata, not payload
- Drops the deprecated `x-` prefix from custom headers per RFC 6648 (`x-meridian-debug-stream-delay-ms` → `meridian-debug-stream-delay-ms`)
- Updates agent reference docs, frontend, test helper, and all affected tests

## Test plan
- [x] All 142 tests pass (API unit, API integration, chat browser, CLI, contracts)
- [x] Lint and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)