### PR TITLE
test: adopt MSW custom request predicates

### DIFF
--- a/apps/chat/src/components/chat.debug.test.tsx
+++ b/apps/chat/src/components/chat.debug.test.tsx
@@ -6,34 +6,33 @@ import {
 } from "../../tests/support/chat-contract";
 import { test } from "../../tests/support/chat-page-fixture";
 import { browserWorker } from "../../tests/support/msw";
+import { withHeaders, withJsonBody } from "../../tests/support/msw-predicates";
 
 describe("Chat UI - debug controls", () => {
 	test("sends the debug delay header when slow stream mode is enabled", async ({
 		chatPage,
 	}) => {
-		let requestHeaders: Record<string, string> | null = null;
 		const eventFactory = createChatEventFactory();
 
 		browserWorker.use(
-			http.post("http://localhost:3201/api/chat", ({ request }) => {
-				requestHeaders = Object.fromEntries(request.headers.entries());
-
-				return createChatStreamResponse([
-					eventFactory.create("turn.completed", {
-						content: "Done.",
-						toolCalls: [],
-					}),
-				]);
-			}),
+			http.post(
+				"http://localhost:3201/api/chat",
+				withHeaders(
+					(headers) => headers.get("meridian-debug-stream-delay-ms") === "120",
+					() =>
+						createChatStreamResponse([
+							eventFactory.create("turn.completed", {
+								content: "Done.",
+								toolCalls: [],
+							}),
+						]),
+				),
+			),
 		);
 
 		await chatPage.toggleSlowStream();
 		await chatPage.sendMessage("Enable slow mode");
 		await chatPage.expectAssistantResponse("Done.");
-
-		expect(requestHeaders).toMatchObject({
-			"meridian-debug-stream-delay-ms": "120",
-		});
 	});
 
 	test("copies a compact debug trace with conversation messages and tool calls", async ({
@@ -50,32 +49,35 @@ describe("Chat UI - debug controls", () => {
 		});
 
 		browserWorker.use(
-			http.post("http://localhost:3201/api/chat", () =>
-				createChatStreamResponse([
-					eventFactory.create("assistant.delta", {
-						delta: "Working through the options...",
-					}),
-					eventFactory.create("tool.completed", {
-						toolCall: {
-							id: "tool-1",
-							input: '{"path":"offers.json"}',
-							name: "read_file",
-							output: '{"offers":2}',
-						},
-					}),
-					eventFactory.create("turn.completed", {
-						content: "I found 2 offers worth comparing.",
-						toolCalls: [
-							{
+			http.post(
+				"http://localhost:3201/api/chat",
+				withJsonBody({ message: "Find me a deal" }, () =>
+					createChatStreamResponse([
+						eventFactory.create("assistant.delta", {
+							delta: "Working through the options...",
+						}),
+						eventFactory.create("tool.completed", {
+							toolCall: {
 								id: "tool-1",
 								input: '{"path":"offers.json"}',
 								name: "read_file",
 								output: '{"offers":2}',
-								state: "completed",
 							},
-						],
-					}),
-				]),
+						}),
+						eventFactory.create("turn.completed", {
+							content: "I found 2 offers worth comparing.",
+							toolCalls: [
+								{
+									id: "tool-1",
+									input: '{"path":"offers.json"}',
+									name: "read_file",
+									output: '{"offers":2}',
+									state: "completed",
+								},
+							],
+						}),
+					]),
+				),
 			),
 		);
 
@@ -127,32 +129,35 @@ describe("Chat UI - debug controls", () => {
 		const eventFactory = createChatEventFactory();
 
 		browserWorker.use(
-			http.post("http://localhost:3201/api/chat", () =>
-				createChatStreamResponse([
-					eventFactory.create("assistant.delta", {
-						delta: "Working through the options...",
-					}),
-					eventFactory.create("tool.completed", {
-						toolCall: {
-							id: "tool-1",
-							input: '{"path":"offers.json"}',
-							name: "read_file",
-							output: '{"offers":2}',
-						},
-					}),
-					eventFactory.create("turn.completed", {
-						content: "I found 2 offers worth comparing.",
-						toolCalls: [
-							{
+			http.post(
+				"http://localhost:3201/api/chat",
+				withJsonBody({ message: "Find me a deal" }, () =>
+					createChatStreamResponse([
+						eventFactory.create("assistant.delta", {
+							delta: "Working through the options...",
+						}),
+						eventFactory.create("tool.completed", {
+							toolCall: {
 								id: "tool-1",
 								input: '{"path":"offers.json"}',
 								name: "read_file",
 								output: '{"offers":2}',
-								state: "completed",
 							},
-						],
-					}),
-				]),
+						}),
+						eventFactory.create("turn.completed", {
+							content: "I found 2 offers worth comparing.",
+							toolCalls: [
+								{
+									id: "tool-1",
+									input: '{"path":"offers.json"}',
+									name: "read_file",
+									output: '{"offers":2}',
+									state: "completed",
+								},
+							],
+						}),
+					]),
+				),
 			),
 		);
 

--- a/apps/chat/src/components/chat.error.test.tsx
+++ b/apps/chat/src/components/chat.error.test.tsx
@@ -6,6 +6,7 @@ import {
 } from "../../tests/support/chat-contract";
 import { test } from "../../tests/support/chat-page-fixture";
 import { browserWorker } from "../../tests/support/msw";
+import { withJsonBody } from "../../tests/support/msw-predicates";
 
 describe("Chat UI - error handling", () => {
 	test("shows an interrupted assistant message when the request fails", async ({
@@ -14,8 +15,14 @@ describe("Chat UI - error handling", () => {
 		browserWorker.use(
 			http.post(
 				"http://localhost:3201/api/chat",
-				() =>
-					new HttpResponse(null, { status: 500, statusText: "Server Error" }),
+				withJsonBody(
+					{ message: "Trigger an error" },
+					() =>
+						new HttpResponse(null, {
+							status: 500,
+							statusText: "Server Error",
+						}),
+				),
 			),
 		);
 
@@ -34,7 +41,10 @@ describe("Chat UI - error handling", () => {
 		const eventFactory = createChatEventFactory();
 
 		browserWorker.use(
-			http.post("http://localhost:3201/api/chat", () => stream.response),
+			http.post(
+				"http://localhost:3201/api/chat",
+				withJsonBody({ message: "Start login" }, () => stream.response),
+			),
 		);
 
 		await chatPage.sendMessage("Start login");

--- a/apps/chat/src/components/chat.journey.test.tsx
+++ b/apps/chat/src/components/chat.journey.test.tsx
@@ -6,6 +6,7 @@ import {
 } from "../../tests/support/chat-contract";
 import { test } from "../../tests/support/chat-page-fixture";
 import { browserWorker } from "../../tests/support/msw";
+import { withJsonBody } from "../../tests/support/msw-predicates";
 
 /**
  * Realistic journey tests that exercise the chat UI with multi-tool-call
@@ -18,14 +19,12 @@ describe("Chat UI - broadband comparison journey", () => {
 		chatPage,
 	}) => {
 		const eventFactory = createChatEventFactory();
-		let requestCount = 0;
 
 		browserWorker.use(
-			http.post("http://localhost:3201/api/chat", () => {
-				requestCount++;
-
-				if (requestCount === 1) {
-					return createChatStreamResponse([
+			http.post(
+				"http://localhost:3201/api/chat",
+				withJsonBody({ message: "Help me compare broadband" }, () =>
+					createChatStreamResponse([
 						eventFactory.create("tool.completed", {
 							toolCall: {
 								id: "tc-1",
@@ -121,126 +120,130 @@ describe("Chat UI - broadband comparison journey", () => {
 								},
 							],
 						}),
-					]);
-				}
-
-				return createChatStreamResponse([
-					eventFactory.create("tool.completed", {
-						toolCall: {
-							id: "tc-6",
-							input:
-								'{"command":["meridian","auth","status","--json"],"timeoutMs":120000}',
-							name: "run_command",
-							output:
-								'{"exitCode":0,"stderr":"","stdout":"{\\"authenticated\\": true}\\n"}',
-						},
-					}),
-					eventFactory.create("tool.completed", {
-						toolCall: {
-							id: "tc-7",
-							input: '{"commandId":"bg-1"}',
-							name: "inspect_background_command",
-							output:
-								'{"command":["meridian","auth","login","--json"],"exitCode":0,"status":"completed"}',
-						},
-					}),
-					eventFactory.create("tool.completed", {
-						toolCall: {
-							id: "tc-8",
-							input:
-								'{"path":"broadband-request.json","contents":"{\\"emailAddress\\":\\"test@test.com\\",\\"data\\":{\\"postcode\\":\\"PE9 UUU\\"}}"}',
-							name: "write_file",
-							output: '{"path":"broadband-request.json"}',
-						},
-					}),
-					eventFactory.create("tool.completed", {
-						toolCall: {
-							id: "tc-9",
-							input:
-								'{"command":["meridian","proposal-requests","create","--product","broadband","--version","1.0","--file","broadband-request.json","--json"],"timeoutMs":120000}',
-							name: "run_command",
-							output:
-								'{"exitCode":0,"stderr":"","stdout":"{\\"id\\":\\"pr-abc123\\",\\"status\\":\\"draft\\"}\\n"}',
-						},
-					}),
-					eventFactory.create("tool.completed", {
-						toolCall: {
-							id: "tc-10",
-							input:
-								'{"command":["meridian","proposals","create","--proposal-request","pr-abc123","--json"],"timeoutMs":120000}',
-							name: "run_command",
-							output:
-								'{"exitCode":0,"stderr":"","stdout":"{\\"id\\":\\"prop-xyz\\",\\"status\\":\\"completed\\"}\\n"}',
-						},
-					}),
-					eventFactory.create("tool.completed", {
-						toolCall: {
-							id: "tc-11",
-							input:
-								'{"command":["meridian","results","get","--proposal","prop-xyz","--json"],"timeoutMs":120000}',
-							name: "run_command",
-							output:
-								'{"exitCode":0,"stderr":"","stdout":"{\\"offerings\\":[{\\"providerName\\":\\"TalkTalk\\",\\"brandName\\":\\"Fibre 65\\"}]}\\n"}',
-						},
-					}),
-					eventFactory.create("turn.completed", {
-						content:
-							"Here are your broadband results:\n\n| Provider | Package | Speed | Monthly |\n|---|---|---:|---:|\n| TalkTalk | Fibre 65 | 67Mbps | £26.00 |",
-						toolCalls: [
-							{
+					]),
+				),
+			),
+			http.post(
+				"http://localhost:3201/api/chat",
+				withJsonBody({ message: "test@test.com, PE9 UUU" }, () =>
+					createChatStreamResponse([
+						eventFactory.create("tool.completed", {
+							toolCall: {
 								id: "tc-6",
+								input:
+									'{"command":["meridian","auth","status","--json"],"timeoutMs":120000}',
 								name: "run_command",
-								input: '{"command":["meridian","auth","status","--json"]}',
 								output:
 									'{"exitCode":0,"stderr":"","stdout":"{\\"authenticated\\": true}\\n"}',
-								state: "completed",
 							},
-							{
+						}),
+						eventFactory.create("tool.completed", {
+							toolCall: {
 								id: "tc-7",
-								name: "inspect_background_command",
 								input: '{"commandId":"bg-1"}',
+								name: "inspect_background_command",
 								output:
-									'{"command":["meridian","auth","login"],"exitCode":0,"status":"completed"}',
-								state: "completed",
+									'{"command":["meridian","auth","login","--json"],"exitCode":0,"status":"completed"}',
 							},
-							{
+						}),
+						eventFactory.create("tool.completed", {
+							toolCall: {
 								id: "tc-8",
+								input:
+									'{"path":"broadband-request.json","contents":"{\\"emailAddress\\":\\"test@test.com\\",\\"data\\":{\\"postcode\\":\\"PE9 UUU\\"}}"}',
 								name: "write_file",
-								input: '{"path":"broadband-request.json","contents":"{}"}',
 								output: '{"path":"broadband-request.json"}',
-								state: "completed",
 							},
-							{
+						}),
+						eventFactory.create("tool.completed", {
+							toolCall: {
 								id: "tc-9",
-								name: "run_command",
 								input:
-									'{"command":["meridian","proposal-requests","create","--product","broadband","--version","1.0","--file","broadband-request.json","--json"]}',
+									'{"command":["meridian","proposal-requests","create","--product","broadband","--version","1.0","--file","broadband-request.json","--json"],"timeoutMs":120000}',
+								name: "run_command",
 								output:
-									'{"exitCode":0,"stderr":"","stdout":"{\\"id\\":\\"pr-abc123\\"}\\n"}',
-								state: "completed",
+									'{"exitCode":0,"stderr":"","stdout":"{\\"id\\":\\"pr-abc123\\",\\"status\\":\\"draft\\"}\\n"}',
 							},
-							{
+						}),
+						eventFactory.create("tool.completed", {
+							toolCall: {
 								id: "tc-10",
-								name: "run_command",
 								input:
-									'{"command":["meridian","proposals","create","--proposal-request","pr-abc123","--json"]}',
+									'{"command":["meridian","proposals","create","--proposal-request","pr-abc123","--json"],"timeoutMs":120000}',
+								name: "run_command",
 								output:
-									'{"exitCode":0,"stderr":"","stdout":"{\\"id\\":\\"prop-xyz\\"}\\n"}',
-								state: "completed",
+									'{"exitCode":0,"stderr":"","stdout":"{\\"id\\":\\"prop-xyz\\",\\"status\\":\\"completed\\"}\\n"}',
 							},
-							{
+						}),
+						eventFactory.create("tool.completed", {
+							toolCall: {
 								id: "tc-11",
-								name: "run_command",
 								input:
-									'{"command":["meridian","results","get","--proposal","prop-xyz","--json"]}',
+									'{"command":["meridian","results","get","--proposal","prop-xyz","--json"],"timeoutMs":120000}',
+								name: "run_command",
 								output:
-									'{"exitCode":0,"stderr":"","stdout":"{\\"offerings\\":[]}\\n"}',
-								state: "completed",
+									'{"exitCode":0,"stderr":"","stdout":"{\\"offerings\\":[{\\"providerName\\":\\"TalkTalk\\",\\"brandName\\":\\"Fibre 65\\"}]}\\n"}',
 							},
-						],
-					}),
-				]);
-			}),
+						}),
+						eventFactory.create("turn.completed", {
+							content:
+								"Here are your broadband results:\n\n| Provider | Package | Speed | Monthly |\n|---|---|---:|---:|\n| TalkTalk | Fibre 65 | 67Mbps | £26.00 |",
+							toolCalls: [
+								{
+									id: "tc-6",
+									name: "run_command",
+									input: '{"command":["meridian","auth","status","--json"]}',
+									output:
+										'{"exitCode":0,"stderr":"","stdout":"{\\"authenticated\\": true}\\n"}',
+									state: "completed",
+								},
+								{
+									id: "tc-7",
+									name: "inspect_background_command",
+									input: '{"commandId":"bg-1"}',
+									output:
+										'{"command":["meridian","auth","login"],"exitCode":0,"status":"completed"}',
+									state: "completed",
+								},
+								{
+									id: "tc-8",
+									name: "write_file",
+									input: '{"path":"broadband-request.json","contents":"{}"}',
+									output: '{"path":"broadband-request.json"}',
+									state: "completed",
+								},
+								{
+									id: "tc-9",
+									name: "run_command",
+									input:
+										'{"command":["meridian","proposal-requests","create","--product","broadband","--version","1.0","--file","broadband-request.json","--json"]}',
+									output:
+										'{"exitCode":0,"stderr":"","stdout":"{\\"id\\":\\"pr-abc123\\"}\\n"}',
+									state: "completed",
+								},
+								{
+									id: "tc-10",
+									name: "run_command",
+									input:
+										'{"command":["meridian","proposals","create","--proposal-request","pr-abc123","--json"]}',
+									output:
+										'{"exitCode":0,"stderr":"","stdout":"{\\"id\\":\\"prop-xyz\\"}\\n"}',
+									state: "completed",
+								},
+								{
+									id: "tc-11",
+									name: "run_command",
+									input:
+										'{"command":["meridian","results","get","--proposal","prop-xyz","--json"]}',
+									output:
+										'{"exitCode":0,"stderr":"","stdout":"{\\"offerings\\":[]}\\n"}',
+									state: "completed",
+								},
+							],
+						}),
+					]),
+				),
+			),
 		);
 
 		// Turn 1: user asks for broadband comparison
@@ -270,14 +273,12 @@ describe("Chat UI - travel insurance journey", () => {
 		chatPage,
 	}) => {
 		const eventFactory = createChatEventFactory();
-		let requestCount = 0;
 
 		browserWorker.use(
-			http.post("http://localhost:3201/api/chat", () => {
-				requestCount++;
-
-				if (requestCount === 1) {
-					return createChatStreamResponse([
+			http.post(
+				"http://localhost:3201/api/chat",
+				withJsonBody({ message: "Help me compare travel insurance" }, () =>
+					createChatStreamResponse([
 						eventFactory.create("tool.completed", {
 							toolCall: {
 								id: "tc-1",
@@ -317,91 +318,100 @@ describe("Chat UI - travel insurance journey", () => {
 								},
 							],
 						}),
-					]);
-				}
-
-				return createChatStreamResponse([
-					eventFactory.create("tool.completed", {
-						toolCall: {
-							id: "tc-3",
-							input:
-								'{"path":"travel-request.json","contents":"{\\"emailAddress\\":\\"tester@email.org\\",\\"data\\":{\\"destination\\":\\"Greece\\"}}"}',
-							name: "write_file",
-							output: '{"path":"travel-request.json"}',
-						},
-					}),
-					eventFactory.create("tool.completed", {
-						toolCall: {
-							id: "tc-4",
-							input:
-								'{"command":["meridian","proposal-requests","create","--product","travel","--version","1.0","--file","travel-request.json","--json"],"timeoutMs":120000}',
-							name: "run_command",
-							output:
-								'{"exitCode":0,"stderr":"","stdout":"{\\"id\\":\\"pr-travel-1\\"}\\n"}',
-						},
-					}),
-					eventFactory.create("tool.completed", {
-						toolCall: {
-							id: "tc-5",
-							input:
-								'{"command":["meridian","proposals","create","--proposal-request","pr-travel-1","--json"],"timeoutMs":120000}',
-							name: "run_command",
-							output:
-								'{"exitCode":0,"stderr":"","stdout":"{\\"id\\":\\"prop-travel-1\\",\\"status\\":\\"completed\\"}\\n"}',
-						},
-					}),
-					eventFactory.create("tool.completed", {
-						toolCall: {
-							id: "tc-6",
-							input:
-								'{"command":["meridian","results","get","--proposal","prop-travel-1","--json"],"timeoutMs":120000}',
-							name: "run_command",
-							output:
-								'{"exitCode":0,"stderr":"","stdout":"{\\"offerings\\":[{\\"providerName\\":\\"Aviva\\",\\"brandName\\":\\"Single Trip Standard\\"}]}\\n"}',
-						},
-					}),
-					eventFactory.create("turn.completed", {
-						content:
-							"I found 2 travel insurance options for Greece:\n\n1. **Aviva** — Single Trip Standard\n   - Price: £12.50\n   - Excess: £100\n\n2. **Admiral** — Annual Gold\n   - Price: £18.75\n   - Excess: £75\n\n**Cheapest**: Aviva at £12.50",
-						toolCalls: [
-							{
-								id: "tc-3",
-								name: "write_file",
-								input: '{"path":"travel-request.json","contents":"{}"}',
-								output: '{"path":"travel-request.json"}',
-								state: "completed",
-							},
-							{
-								id: "tc-4",
-								name: "run_command",
-								input:
-									'{"command":["meridian","proposal-requests","create","--product","travel","--version","1.0","--file","travel-request.json","--json"]}',
-								output:
-									'{"exitCode":0,"stderr":"","stdout":"{\\"id\\":\\"pr-travel-1\\"}\\n"}',
-								state: "completed",
-							},
-							{
-								id: "tc-5",
-								name: "run_command",
-								input:
-									'{"command":["meridian","proposals","create","--proposal-request","pr-travel-1","--json"]}',
-								output:
-									'{"exitCode":0,"stderr":"","stdout":"{\\"id\\":\\"prop-travel-1\\"}\\n"}',
-								state: "completed",
-							},
-							{
-								id: "tc-6",
-								name: "run_command",
-								input:
-									'{"command":["meridian","results","get","--proposal","prop-travel-1","--json"]}',
-								output:
-									'{"exitCode":0,"stderr":"","stdout":"{\\"offerings\\":[]}\\n"}',
-								state: "completed",
-							},
-						],
-					}),
-				]);
-			}),
+					]),
+				),
+			),
+			http.post(
+				"http://localhost:3201/api/chat",
+				withJsonBody(
+					{
+						message:
+							"Email: tester@email.org, Greece, 1st April 2026, 7 nights, 2 adults",
+					},
+					() =>
+						createChatStreamResponse([
+							eventFactory.create("tool.completed", {
+								toolCall: {
+									id: "tc-3",
+									input:
+										'{"path":"travel-request.json","contents":"{\\"emailAddress\\":\\"tester@email.org\\",\\"data\\":{\\"destination\\":\\"Greece\\"}}"}',
+									name: "write_file",
+									output: '{"path":"travel-request.json"}',
+								},
+							}),
+							eventFactory.create("tool.completed", {
+								toolCall: {
+									id: "tc-4",
+									input:
+										'{"command":["meridian","proposal-requests","create","--product","travel","--version","1.0","--file","travel-request.json","--json"],"timeoutMs":120000}',
+									name: "run_command",
+									output:
+										'{"exitCode":0,"stderr":"","stdout":"{\\"id\\":\\"pr-travel-1\\"}\\n"}',
+								},
+							}),
+							eventFactory.create("tool.completed", {
+								toolCall: {
+									id: "tc-5",
+									input:
+										'{"command":["meridian","proposals","create","--proposal-request","pr-travel-1","--json"],"timeoutMs":120000}',
+									name: "run_command",
+									output:
+										'{"exitCode":0,"stderr":"","stdout":"{\\"id\\":\\"prop-travel-1\\",\\"status\\":\\"completed\\"}\\n"}',
+								},
+							}),
+							eventFactory.create("tool.completed", {
+								toolCall: {
+									id: "tc-6",
+									input:
+										'{"command":["meridian","results","get","--proposal","prop-travel-1","--json"],"timeoutMs":120000}',
+									name: "run_command",
+									output:
+										'{"exitCode":0,"stderr":"","stdout":"{\\"offerings\\":[{\\"providerName\\":\\"Aviva\\",\\"brandName\\":\\"Single Trip Standard\\"}]}\\n"}',
+								},
+							}),
+							eventFactory.create("turn.completed", {
+								content:
+									"I found 2 travel insurance options for Greece:\n\n1. **Aviva** — Single Trip Standard\n   - Price: £12.50\n   - Excess: £100\n\n2. **Admiral** — Annual Gold\n   - Price: £18.75\n   - Excess: £75\n\n**Cheapest**: Aviva at £12.50",
+								toolCalls: [
+									{
+										id: "tc-3",
+										name: "write_file",
+										input: '{"path":"travel-request.json","contents":"{}"}',
+										output: '{"path":"travel-request.json"}',
+										state: "completed",
+									},
+									{
+										id: "tc-4",
+										name: "run_command",
+										input:
+											'{"command":["meridian","proposal-requests","create","--product","travel","--version","1.0","--file","travel-request.json","--json"]}',
+										output:
+											'{"exitCode":0,"stderr":"","stdout":"{\\"id\\":\\"pr-travel-1\\"}\\n"}',
+										state: "completed",
+									},
+									{
+										id: "tc-5",
+										name: "run_command",
+										input:
+											'{"command":["meridian","proposals","create","--proposal-request","pr-travel-1","--json"]}',
+										output:
+											'{"exitCode":0,"stderr":"","stdout":"{\\"id\\":\\"prop-travel-1\\"}\\n"}',
+										state: "completed",
+									},
+									{
+										id: "tc-6",
+										name: "run_command",
+										input:
+											'{"command":["meridian","results","get","--proposal","prop-travel-1","--json"]}',
+										output:
+											'{"exitCode":0,"stderr":"","stdout":"{\\"offerings\\":[]}\\n"}',
+										state: "completed",
+									},
+								],
+							}),
+						]),
+				),
+			),
 		);
 
 		// Turn 1: user asks about travel insurance

--- a/apps/chat/src/components/chat.loading.test.tsx
+++ b/apps/chat/src/components/chat.loading.test.tsx
@@ -6,6 +6,7 @@ import {
 } from "../../tests/support/chat-contract";
 import { test } from "../../tests/support/chat-page-fixture";
 import { browserWorker } from "../../tests/support/msw";
+import { withJsonBody } from "../../tests/support/msw-predicates";
 
 describe("Chat UI - loading state", () => {
 	test("disables controls while a chat request is still streaming", async ({
@@ -15,7 +16,10 @@ describe("Chat UI - loading state", () => {
 		const eventFactory = createChatEventFactory();
 
 		browserWorker.use(
-			http.post("http://localhost:3201/api/chat", () => stream.response),
+			http.post(
+				"http://localhost:3201/api/chat",
+				withJsonBody({ message: "Find me a deal" }, () => stream.response),
+			),
 		);
 
 		await chatPage.sendMessage("Find me a deal");

--- a/apps/chat/src/components/chat.submission.test.tsx
+++ b/apps/chat/src/components/chat.submission.test.tsx
@@ -4,48 +4,55 @@ import {
 	createChatEventFactory,
 	createChatStreamResponse,
 } from "../../tests/support/chat-contract";
-import { expect, test } from "../../tests/support/chat-page-fixture";
+import { test } from "../../tests/support/chat-page-fixture";
 import { browserWorker } from "../../tests/support/msw";
+import { withHeaders, withJsonBody } from "../../tests/support/msw-predicates";
 
 describe("Chat UI - submission and streaming", () => {
 	test("submits a message and renders streamed contract events", async ({
 		chatPage,
 	}) => {
-		let requestBody: unknown;
-		let requestHeaders: Record<string, string> | null = null;
 		const eventFactory = createChatEventFactory();
 
 		browserWorker.use(
-			http.post("http://localhost:3201/api/chat", async ({ request }) => {
-				requestBody = await request.json();
-				requestHeaders = Object.fromEntries(request.headers.entries());
-
-				return createChatStreamResponse([
-					eventFactory.create("assistant.delta", {
-						delta: "Working through the options...",
-					}),
-					eventFactory.create("tool.completed", {
-						toolCall: {
-							id: "tool-1",
-							input: '{"path":"offers.json"}',
-							name: "read_file",
-							output: '{"offers":2}',
-						},
-					}),
-					eventFactory.create("turn.completed", {
-						content: "I found 2 offers worth comparing.",
-						toolCalls: [
-							{
-								id: "tool-1",
-								input: '{"path":"offers.json"}',
-								name: "read_file",
-								output: '{"offers":2}',
-								state: "completed",
-							},
-						],
-					}),
-				]);
-			}),
+			http.post(
+				"http://localhost:3201/api/chat",
+				withJsonBody(
+					{ message: "Find me a deal" },
+					withHeaders(
+						(headers) =>
+							headers.get("content-type") === "application/json" &&
+							headers.has("session-id") &&
+							headers.get("meridian-debug-stream-delay-ms") === "0",
+						() =>
+							createChatStreamResponse([
+								eventFactory.create("assistant.delta", {
+									delta: "Working through the options...",
+								}),
+								eventFactory.create("tool.completed", {
+									toolCall: {
+										id: "tool-1",
+										input: '{"path":"offers.json"}',
+										name: "read_file",
+										output: '{"offers":2}',
+									},
+								}),
+								eventFactory.create("turn.completed", {
+									content: "I found 2 offers worth comparing.",
+									toolCalls: [
+										{
+											id: "tool-1",
+											input: '{"path":"offers.json"}',
+											name: "read_file",
+											output: '{"offers":2}',
+											state: "completed",
+										},
+									],
+								}),
+							]),
+					),
+				),
+			),
 		);
 
 		await chatPage.expectReady();
@@ -55,13 +62,5 @@ describe("Chat UI - submission and streaming", () => {
 		await chatPage.expectAssistantResponse("I found 2 offers worth comparing.");
 		await chatPage.expectToolActivityVisible("Read a file");
 		await chatPage.expectMessageInputValue("");
-		expect(requestBody).toMatchObject({
-			message: "Find me a deal",
-		});
-		expect(requestHeaders).toMatchObject({
-			"content-type": "application/json",
-			"session-id": expect.any(String),
-			"meridian-debug-stream-delay-ms": "0",
-		});
 	});
 });

--- a/apps/chat/tests/support/msw-predicates.ts
+++ b/apps/chat/tests/support/msw-predicates.ts
@@ -1,0 +1,76 @@
+import type { HttpResponseResolver } from "msw";
+
+/**
+ * Higher-order resolver that only matches requests whose JSON body
+ * is a superset of the expected object (subset / partial matching).
+ *
+ * Falls through (returns `undefined`) when the body does not match,
+ * letting MSW try the next handler or raise an unhandled-request error.
+ *
+ * @see https://mswjs.io/docs/best-practices/custom-request-predicate
+ */
+export function withJsonBody(
+	expected: Record<string, unknown>,
+	resolver: HttpResponseResolver,
+): HttpResponseResolver {
+	return async (args) => {
+		const contentType = args.request.headers.get("Content-Type") ?? "";
+
+		if (!contentType.includes("application/json")) {
+			return;
+		}
+
+		const actual = await args.request.clone().json();
+
+		if (!isSubset(actual, expected)) {
+			return;
+		}
+
+		return resolver(args);
+	};
+}
+
+/**
+ * Higher-order resolver that only matches requests whose headers
+ * satisfy the given predicate function.
+ *
+ * @see https://mswjs.io/docs/best-practices/custom-request-predicate
+ */
+export function withHeaders(
+	predicate: (headers: Headers) => boolean,
+	resolver: HttpResponseResolver,
+): HttpResponseResolver {
+	return (args) => {
+		if (!predicate(args.request.headers)) {
+			return;
+		}
+
+		return resolver(args);
+	};
+}
+
+function isSubset(actual: unknown, expected: unknown): boolean {
+	if (expected === null || expected === undefined) {
+		return actual === expected;
+	}
+
+	if (typeof expected !== "object") {
+		return actual === expected;
+	}
+
+	if (typeof actual !== "object" || actual === null) {
+		return false;
+	}
+
+	if (Array.isArray(expected)) {
+		return (
+			Array.isArray(actual) &&
+			actual.length === expected.length &&
+			expected.every((val, i) => isSubset(actual[i], val))
+		);
+	}
+
+	return Object.entries(expected as Record<string, unknown>).every(
+		([key, value]) => isSubset((actual as Record<string, unknown>)[key], value),
+	);
+}

--- a/apps/cli/src/auth/lib/device-flow.test.ts
+++ b/apps/cli/src/auth/lib/device-flow.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@/auth/lib/device-flow";
 import { AuthDeviceFlowError } from "@/errors";
 import { createUnsignedJwt } from "../../../tests/helpers/jwt";
+import { withFormBody } from "../../../tests/helpers/msw-predicates";
 import { mswServer } from "../../../tests/setup/msw";
 
 const issuer = "http://localhost:8180/realms/meridian";
@@ -19,36 +20,51 @@ describe("device flow", () => {
 		let tokenPolls = 0;
 
 		mswServer.use(
-			http.post(authDeviceUrl, async ({ request }) => {
-				expect(await request.text()).toBe(
-					"client_id=meridian-cli&scope=openid+email+profile",
-				);
-				return HttpResponse.json({
-					device_code: "device-code",
-					user_code: "ABCD-1234",
-					verification_uri_complete:
-						"http://localhost:8180/device?user_code=ABCD-1234",
-					interval: 5,
-				});
-			}),
-			http.post(tokenUrl, () => {
-				tokenPolls += 1;
-				if (tokenPolls === 1) {
-					return HttpResponse.json(
-						{ error: "authorization_pending" },
-						{ status: 400 },
-					);
-				}
+			http.post(
+				authDeviceUrl,
+				withFormBody(
+					{
+						client_id: "meridian-cli",
+						scope: "openid email profile",
+					},
+					() =>
+						HttpResponse.json({
+							device_code: "device-code",
+							user_code: "ABCD-1234",
+							verification_uri_complete:
+								"http://localhost:8180/device?user_code=ABCD-1234",
+							interval: 5,
+						}),
+				),
+			),
+			http.post(
+				tokenUrl,
+				withFormBody(
+					{
+						grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+						client_id: "meridian-cli",
+						device_code: "device-code",
+					},
+					() => {
+						tokenPolls += 1;
+						if (tokenPolls === 1) {
+							return HttpResponse.json(
+								{ error: "authorization_pending" },
+								{ status: 400 },
+							);
+						}
 
-				return HttpResponse.json({
-					access_token: "access-token",
-					refresh_token: "refresh-token",
-					id_token: createUnsignedJwt({
-						email: "john.doe@example.com",
-					}),
-					expires_in: 300,
-				});
-			}),
+						return HttpResponse.json({
+							access_token: "access-token",
+							refresh_token: "refresh-token",
+							id_token: createUnsignedJwt({
+								email: "john.doe@example.com",
+							}),
+							expires_in: 300,
+						});
+					},
+				),
+			),
 		);
 
 		const result = await authenticateWithDeviceFlow(
@@ -81,14 +97,22 @@ describe("device flow", () => {
 
 	it("normalizes host.docker.internal verification URLs for the browser flow", async () => {
 		mswServer.use(
-			http.post(authDeviceUrl, () =>
-				HttpResponse.json({
-					device_code: "device-code",
-					user_code: "ABCD-1234",
-					verification_uri_complete:
-						"http://host.docker.internal:8080/realms/meridian/device?user_code=ABCD-1234",
-					interval: 5,
-				}),
+			http.post(
+				authDeviceUrl,
+				withFormBody(
+					{
+						client_id: "meridian-cli",
+						scope: "openid email profile",
+					},
+					() =>
+						HttpResponse.json({
+							device_code: "device-code",
+							user_code: "ABCD-1234",
+							verification_uri_complete:
+								"http://host.docker.internal:8080/realms/meridian/device?user_code=ABCD-1234",
+							interval: 5,
+						}),
+				),
 			),
 		);
 
@@ -114,10 +138,18 @@ describe("device flow", () => {
 
 	it("fails when the device authorisation response shape is invalid", async () => {
 		mswServer.use(
-			http.post(authDeviceUrl, () =>
-				HttpResponse.json({
-					device_code: "device-code",
-				}),
+			http.post(
+				authDeviceUrl,
+				withFormBody(
+					{
+						client_id: "meridian-cli",
+						scope: "openid email profile",
+					},
+					() =>
+						HttpResponse.json({
+							device_code: "device-code",
+						}),
+				),
 			),
 		);
 
@@ -137,12 +169,20 @@ describe("device flow", () => {
 
 	it("fails with an auth device flow error when device authorisation is rejected", async () => {
 		mswServer.use(
-			http.post(authDeviceUrl, () =>
-				HttpResponse.json(
+			http.post(
+				authDeviceUrl,
+				withFormBody(
 					{
-						error: "invalid_client",
+						client_id: "meridian-cli",
+						scope: "openid email profile",
 					},
-					{ status: 400 },
+					() =>
+						HttpResponse.json(
+							{
+								error: "invalid_client",
+							},
+							{ status: 400 },
+						),
 				),
 			),
 		);
@@ -163,10 +203,19 @@ describe("device flow", () => {
 
 	it("fails when the token success response shape is invalid", async () => {
 		mswServer.use(
-			http.post(tokenUrl, () =>
-				HttpResponse.json({
-					token: "access-token",
-				}),
+			http.post(
+				tokenUrl,
+				withFormBody(
+					{
+						grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+						client_id: "meridian-cli",
+						device_code: "device-code",
+					},
+					() =>
+						HttpResponse.json({
+							token: "access-token",
+						}),
+				),
 			),
 		);
 
@@ -193,13 +242,22 @@ describe("device flow", () => {
 
 	it("fails when the id token payload is malformed", async () => {
 		mswServer.use(
-			http.post(tokenUrl, () =>
-				HttpResponse.json({
-					access_token: "access-token",
-					refresh_token: "refresh-token",
-					id_token: "not.a.valid.jwt",
-					expires_in: 300,
-				}),
+			http.post(
+				tokenUrl,
+				withFormBody(
+					{
+						grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+						client_id: "meridian-cli",
+						device_code: "device-code",
+					},
+					() =>
+						HttpResponse.json({
+							access_token: "access-token",
+							refresh_token: "refresh-token",
+							id_token: "not.a.valid.jwt",
+							expires_in: 300,
+						}),
+				),
 			),
 		);
 
@@ -226,12 +284,21 @@ describe("device flow", () => {
 
 	it("fails when the token response does not include an id token", async () => {
 		mswServer.use(
-			http.post(tokenUrl, () =>
-				HttpResponse.json({
-					access_token: "access-token",
-					refresh_token: "refresh-token",
-					expires_in: 300,
-				}),
+			http.post(
+				tokenUrl,
+				withFormBody(
+					{
+						grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+						client_id: "meridian-cli",
+						device_code: "device-code",
+					},
+					() =>
+						HttpResponse.json({
+							access_token: "access-token",
+							refresh_token: "refresh-token",
+							expires_in: 300,
+						}),
+				),
 			),
 		);
 

--- a/apps/cli/src/auth/lib/token.test.ts
+++ b/apps/cli/src/auth/lib/token.test.ts
@@ -6,6 +6,7 @@ import {
 	refreshStoredCredentials,
 } from "@/auth/lib/token";
 import { createUnsignedJwt } from "../../../tests/helpers/jwt";
+import { withFormBody } from "../../../tests/helpers/msw-predicates";
 import { mswServer } from "../../../tests/setup/msw";
 
 const issuer = "http://localhost:8180/realms/meridian";
@@ -43,19 +44,25 @@ describe("token", () => {
 
 	it("refreshes expired credentials using the refresh token", async () => {
 		mswServer.use(
-			http.post(tokenUrl, async ({ request }) => {
-				expect(await request.text()).toBe(
-					"grant_type=refresh_token&client_id=meridian-cli&refresh_token=old-refresh",
-				);
-				return HttpResponse.json({
-					access_token: "new-access",
-					refresh_token: "new-refresh",
-					id_token: createUnsignedJwt({
-						email: "john.doe@example.com",
-					}),
-					expires_in: 300,
-				});
-			}),
+			http.post(
+				tokenUrl,
+				withFormBody(
+					{
+						grant_type: "refresh_token",
+						client_id: "meridian-cli",
+						refresh_token: "old-refresh",
+					},
+					() =>
+						HttpResponse.json({
+							access_token: "new-access",
+							refresh_token: "new-refresh",
+							id_token: createUnsignedJwt({
+								email: "john.doe@example.com",
+							}),
+							expires_in: 300,
+						}),
+				),
+			),
 		);
 
 		const refreshed = await refreshStoredCredentials(
@@ -85,10 +92,19 @@ describe("token", () => {
 
 	it("returns null when the refresh response shape is invalid", async () => {
 		mswServer.use(
-			http.post(tokenUrl, () =>
-				HttpResponse.json({
-					token: "new-access",
-				}),
+			http.post(
+				tokenUrl,
+				withFormBody(
+					{
+						grant_type: "refresh_token",
+						client_id: "meridian-cli",
+						refresh_token: "old-refresh",
+					},
+					() =>
+						HttpResponse.json({
+							token: "new-access",
+						}),
+				),
 			),
 		);
 
@@ -113,13 +129,22 @@ describe("token", () => {
 
 	it("falls back to the existing user when the refreshed id token payload is malformed", async () => {
 		mswServer.use(
-			http.post(tokenUrl, () =>
-				HttpResponse.json({
-					access_token: "new-access",
-					refresh_token: "new-refresh",
-					id_token: "not.a.valid.jwt",
-					expires_in: 300,
-				}),
+			http.post(
+				tokenUrl,
+				withFormBody(
+					{
+						grant_type: "refresh_token",
+						client_id: "meridian-cli",
+						refresh_token: "old-refresh",
+					},
+					() =>
+						HttpResponse.json({
+							access_token: "new-access",
+							refresh_token: "new-refresh",
+							id_token: "not.a.valid.jwt",
+							expires_in: 300,
+						}),
+				),
 			),
 		);
 

--- a/apps/cli/src/auth/login.test.ts
+++ b/apps/cli/src/auth/login.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { DEFAULT_AUTH_CLIENT_ID, DEFAULT_AUTH_ISSUER } from "@/auth/session";
 import { runCli } from "@/cli";
 import { createUnsignedJwt } from "../../tests/helpers/jwt";
+import { withFormBody } from "../../tests/helpers/msw-predicates";
 import { createWritable } from "../../tests/helpers/streams";
 import { createTempHome } from "../../tests/helpers/temp-home";
 import { mswServer } from "../../tests/setup/msw";
@@ -12,29 +13,41 @@ describe("auth login", () => {
 		await using home = await createTempHome();
 		const stdout = createWritable(false);
 		const stderr = createWritable();
-		let requestBody = "";
 		mswServer.use(
 			http.post(
 				`${DEFAULT_AUTH_ISSUER}/protocol/openid-connect/auth/device`,
-				async ({ request }) => {
-					requestBody = await request.text();
-					return HttpResponse.json({
-						device_code: "device-code",
-						user_code: "ABCD-1234",
-						verification_uri_complete: `${DEFAULT_AUTH_ISSUER}/device?user_code=ABCD-1234`,
-						interval: 5,
-					});
-				},
+				withFormBody(
+					{
+						client_id: DEFAULT_AUTH_CLIENT_ID,
+						scope: "openid email profile",
+					},
+					() =>
+						HttpResponse.json({
+							device_code: "device-code",
+							user_code: "ABCD-1234",
+							verification_uri_complete: `${DEFAULT_AUTH_ISSUER}/device?user_code=ABCD-1234`,
+							interval: 5,
+						}),
+				),
 			),
-			http.post(`${DEFAULT_AUTH_ISSUER}/protocol/openid-connect/token`, () =>
-				HttpResponse.json({
-					access_token: "access-token",
-					refresh_token: "refresh-token",
-					id_token: createUnsignedJwt({
-						email: "john.doe@example.com",
-					}),
-					expires_in: 300,
-				}),
+			http.post(
+				`${DEFAULT_AUTH_ISSUER}/protocol/openid-connect/token`,
+				withFormBody(
+					{
+						grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+						client_id: DEFAULT_AUTH_CLIENT_ID,
+						device_code: "device-code",
+					},
+					() =>
+						HttpResponse.json({
+							access_token: "access-token",
+							refresh_token: "refresh-token",
+							id_token: createUnsignedJwt({
+								email: "john.doe@example.com",
+							}),
+							expires_in: 300,
+						}),
+				),
 			),
 		);
 
@@ -47,7 +60,6 @@ describe("auth login", () => {
 		});
 
 		expect(exitCode).toBe(0);
-		expect(requestBody).toContain(`client_id=${DEFAULT_AUTH_CLIENT_ID}`);
 		expect(stdout.output()).toContain('"status":"pending"');
 		expect(stdout.output()).toContain('"status":"authenticated"');
 		expect(stderr.output()).toBe("");
@@ -62,35 +74,48 @@ describe("auth login", () => {
 		mswServer.use(
 			http.post(
 				"http://localhost:8180/realms/meridian/protocol/openid-connect/auth/device",
-				() =>
-					HttpResponse.json({
-						device_code: "device-code",
-						user_code: "ABCD-1234",
-						verification_uri_complete:
-							"http://localhost:8180/device?user_code=ABCD-1234",
-						interval: 5,
-					}),
+				withFormBody(
+					{
+						client_id: "meridian-cli",
+						scope: "openid email profile",
+					},
+					() =>
+						HttpResponse.json({
+							device_code: "device-code",
+							user_code: "ABCD-1234",
+							verification_uri_complete:
+								"http://localhost:8180/device?user_code=ABCD-1234",
+							interval: 5,
+						}),
+				),
 			),
 			http.post(
 				"http://localhost:8180/realms/meridian/protocol/openid-connect/token",
-				() => {
-					tokenPolls += 1;
-					if (tokenPolls === 1) {
-						return HttpResponse.json(
-							{ error: "authorization_pending" },
-							{ status: 400 },
-						);
-					}
+				withFormBody(
+					{
+						grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+						client_id: "meridian-cli",
+						device_code: "device-code",
+					},
+					() => {
+						tokenPolls += 1;
+						if (tokenPolls === 1) {
+							return HttpResponse.json(
+								{ error: "authorization_pending" },
+								{ status: 400 },
+							);
+						}
 
-					return HttpResponse.json({
-						access_token: "access-token",
-						refresh_token: "refresh-token",
-						id_token: createUnsignedJwt({
-							email: "john.doe@example.com",
-						}),
-						expires_in: 300,
-					});
-				},
+						return HttpResponse.json({
+							access_token: "access-token",
+							refresh_token: "refresh-token",
+							id_token: createUnsignedJwt({
+								email: "john.doe@example.com",
+							}),
+							expires_in: 300,
+						});
+					},
+				),
 			),
 		);
 
@@ -130,26 +155,39 @@ describe("auth login", () => {
 		mswServer.use(
 			http.post(
 				"http://host.docker.internal:8080/realms/meridian/protocol/openid-connect/auth/device",
-				() =>
-					HttpResponse.json({
-						device_code: "device-code",
-						user_code: "ABCD-1234",
-						verification_uri_complete:
-							"http://host.docker.internal:8080/realms/meridian/device?user_code=ABCD-1234",
-						interval: 5,
-					}),
+				withFormBody(
+					{
+						client_id: "meridian-cli",
+						scope: "openid email profile",
+					},
+					() =>
+						HttpResponse.json({
+							device_code: "device-code",
+							user_code: "ABCD-1234",
+							verification_uri_complete:
+								"http://host.docker.internal:8080/realms/meridian/device?user_code=ABCD-1234",
+							interval: 5,
+						}),
+				),
 			),
 			http.post(
 				"http://host.docker.internal:8080/realms/meridian/protocol/openid-connect/token",
-				() =>
-					HttpResponse.json({
-						access_token: "access-token",
-						refresh_token: "refresh-token",
-						id_token: createUnsignedJwt({
-							email: "john.doe@example.com",
+				withFormBody(
+					{
+						grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+						client_id: "meridian-cli",
+						device_code: "device-code",
+					},
+					() =>
+						HttpResponse.json({
+							access_token: "access-token",
+							refresh_token: "refresh-token",
+							id_token: createUnsignedJwt({
+								email: "john.doe@example.com",
+							}),
+							expires_in: 300,
 						}),
-						expires_in: 300,
-					}),
+				),
 			),
 		);
 
@@ -181,35 +219,48 @@ describe("auth login", () => {
 		mswServer.use(
 			http.post(
 				"http://localhost:8180/realms/meridian/protocol/openid-connect/auth/device",
-				() =>
-					HttpResponse.json({
-						device_code: "device-code",
-						user_code: "ABCD-1234",
-						verification_uri_complete:
-							"http://localhost:8180/device?user_code=ABCD-1234",
-						interval: 5,
-					}),
+				withFormBody(
+					{
+						client_id: "meridian-cli",
+						scope: "openid email profile",
+					},
+					() =>
+						HttpResponse.json({
+							device_code: "device-code",
+							user_code: "ABCD-1234",
+							verification_uri_complete:
+								"http://localhost:8180/device?user_code=ABCD-1234",
+							interval: 5,
+						}),
+				),
 			),
 			http.post(
 				"http://localhost:8180/realms/meridian/protocol/openid-connect/token",
-				() => {
-					tokenPolls += 1;
-					if (tokenPolls === 1) {
-						return HttpResponse.json(
-							{ error: "authorization_pending" },
-							{ status: 400 },
-						);
-					}
+				withFormBody(
+					{
+						grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+						client_id: "meridian-cli",
+						device_code: "device-code",
+					},
+					() => {
+						tokenPolls += 1;
+						if (tokenPolls === 1) {
+							return HttpResponse.json(
+								{ error: "authorization_pending" },
+								{ status: 400 },
+							);
+						}
 
-					return HttpResponse.json({
-						access_token: "access-token",
-						refresh_token: "refresh-token",
-						id_token: createUnsignedJwt({
-							email: "john.doe@example.com",
-						}),
-						expires_in: 300,
-					});
-				},
+						return HttpResponse.json({
+							access_token: "access-token",
+							refresh_token: "refresh-token",
+							id_token: createUnsignedJwt({
+								email: "john.doe@example.com",
+							}),
+							expires_in: 300,
+						});
+					},
+				),
 			),
 		);
 
@@ -291,14 +342,20 @@ describe("auth login", () => {
 		mswServer.use(
 			http.post(
 				"http://localhost:8180/realms/meridian/protocol/openid-connect/auth/device",
-				() =>
-					HttpResponse.json({
-						device_code: "device-code",
-						user_code: "ABCD-1234",
-						verification_uri_complete:
-							"http://localhost:8180/device?user_code=ABCD-1234",
-						interval: 5,
-					}),
+				withFormBody(
+					{
+						client_id: "meridian-cli",
+						scope: "openid email profile",
+					},
+					() =>
+						HttpResponse.json({
+							device_code: "device-code",
+							user_code: "ABCD-1234",
+							verification_uri_complete:
+								"http://localhost:8180/device?user_code=ABCD-1234",
+							interval: 5,
+						}),
+				),
 			),
 			http.post(
 				"http://localhost:8180/realms/meridian/protocol/openid-connect/token",

--- a/apps/cli/src/auth/logout.test.ts
+++ b/apps/cli/src/auth/logout.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
 import { runCli } from "@/cli";
+import { withFormBody } from "../../tests/helpers/msw-predicates";
 import { createWritable } from "../../tests/helpers/streams";
 import { createTempHome } from "../../tests/helpers/temp-home";
 import { mswServer } from "../../tests/setup/msw";
@@ -18,14 +19,16 @@ describe("auth logout", () => {
 		});
 		const stdout = createWritable(false);
 		const stderr = createWritable();
-		let requestBody = "";
 		mswServer.use(
 			http.post(
 				"http://localhost:8180/realms/meridian/protocol/openid-connect/logout",
-				async ({ request }) => {
-					requestBody = await request.text();
-					return new HttpResponse(null, { status: 204 });
-				},
+				withFormBody(
+					{
+						client_id: "meridian-cli",
+						refresh_token: "refresh-token",
+					},
+					() => new HttpResponse(null, { status: 204 }),
+				),
 			),
 		);
 
@@ -41,9 +44,6 @@ describe("auth logout", () => {
 		});
 
 		expect(exitCode).toBe(0);
-		expect(requestBody).toBe(
-			"client_id=meridian-cli&refresh_token=refresh-token",
-		);
 		expect(JSON.parse(stdout.output())).toEqual({
 			loggedOut: true,
 		});

--- a/apps/cli/src/auth/status.test.ts
+++ b/apps/cli/src/auth/status.test.ts
@@ -4,6 +4,7 @@ import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
 import { runCli } from "@/cli";
 import { createUnsignedJwt } from "../../tests/helpers/jwt";
+import { withFormBody } from "../../tests/helpers/msw-predicates";
 import { createWritable } from "../../tests/helpers/streams";
 import { createTempHome } from "../../tests/helpers/temp-home";
 import { mswServer } from "../../tests/setup/msw";
@@ -38,15 +39,22 @@ describe("auth status", () => {
 		mswServer.use(
 			http.post(
 				"http://localhost:8180/realms/meridian/protocol/openid-connect/token",
-				() =>
-					HttpResponse.json({
-						access_token: "fresh-access",
-						refresh_token: "fresh-refresh",
-						id_token: createUnsignedJwt({
-							email: "john.doe@example.com",
+				withFormBody(
+					{
+						grant_type: "refresh_token",
+						client_id: "meridian-cli",
+						refresh_token: "refresh-token",
+					},
+					() =>
+						HttpResponse.json({
+							access_token: "fresh-access",
+							refresh_token: "fresh-refresh",
+							id_token: createUnsignedJwt({
+								email: "john.doe@example.com",
+							}),
+							expires_in: 300,
 						}),
-						expires_in: 300,
-					}),
+				),
 			),
 		);
 

--- a/apps/cli/src/proposal-requests/create.test.ts
+++ b/apps/cli/src/proposal-requests/create.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
 import { runCli } from "@/cli";
+import { withFormBody } from "../../tests/helpers/msw-predicates";
 import { createWritable } from "../../tests/helpers/streams";
 import { createTempHome } from "../../tests/helpers/temp-home";
 import { mswServer } from "../../tests/setup/msw";
@@ -313,17 +314,24 @@ describe("proposal-requests create", () => {
 		mswServer.use(
 			http.post(
 				"http://localhost:8180/realms/meridian/protocol/openid-connect/token",
-				() =>
-					HttpResponse.json({
-						access_token: "fresh-access",
-						refresh_token: "fresh-refresh",
-						id_token: [
-							"eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0",
-							"eyJlbWFpbCI6ImphbmUuZG9lQGV4YW1wbGUuY29tIn0",
-							"",
-						].join("."),
-						expires_in: 300,
-					}),
+				withFormBody(
+					{
+						grant_type: "refresh_token",
+						client_id: "meridian-cli",
+						refresh_token: "refresh-token",
+					},
+					() =>
+						HttpResponse.json({
+							access_token: "fresh-access",
+							refresh_token: "fresh-refresh",
+							id_token: [
+								"eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0",
+								"eyJlbWFpbCI6ImphbmUuZG9lQGV4YW1wbGUuY29tIn0",
+								"",
+							].join("."),
+							expires_in: 300,
+						}),
+				),
 			),
 		);
 

--- a/apps/cli/tests/helpers/msw-predicates.ts
+++ b/apps/cli/tests/helpers/msw-predicates.ts
@@ -1,0 +1,33 @@
+import type { HttpResponseResolver } from "msw";
+
+/**
+ * Higher-order resolver that only matches requests whose URL-encoded
+ * form body contains exactly the specified parameters.
+ *
+ * If the body does not match, the handler returns `undefined` so MSW
+ * falls through to the next handler (or triggers an unhandled-request
+ * error when no handler matches).
+ *
+ * @see https://mswjs.io/docs/best-practices/custom-request-predicate
+ */
+export function withFormBody(
+	expected: Record<string, string>,
+	resolver: HttpResponseResolver,
+): HttpResponseResolver {
+	return async (args) => {
+		const actual = new URLSearchParams(await args.request.clone().text());
+		const expectedEntries = Object.entries(expected);
+
+		if (actual.size !== expectedEntries.length) {
+			return;
+		}
+
+		for (const [key, value] of expectedEntries) {
+			if (actual.get(key) !== value) {
+				return;
+			}
+		}
+
+		return resolver(args);
+	};
+}


### PR DESCRIPTION
## Summary
- Add composable higher-order MSW resolver predicates (`withFormBody`, `withJsonBody`, `withHeaders`) that guard on request body/headers before delegating to the actual resolver, following [MSW custom request predicate best practices](https://mswjs.io/docs/best-practices/custom-request-predicate/)
- Migrate all existing ad-hoc request verification patterns (mutable variable captures, inline `expect()` calls in handlers) to use these predicates
- Add request verification to handlers that previously had none (auth, token refresh, chat endpoints)

## Test plan
- [x] All 201 tests pass across all packages
- [x] Lint and typecheck clean
- [x] Predicate mismatches cause MSW to fall through (producing unhandled request errors), verified by existing `onUnhandledRequest: "error"` config

🤖 Generated with [Claude Code](https://claude.com/claude-code)