### PR TITLE
test: close coverage gaps in CLI and API test suites

### DIFF
--- a/apps/api/src/lib/agent.test.ts
+++ b/apps/api/src/lib/agent.test.ts
@@ -1,3 +1,4 @@
+import { GraphRecursionError } from "@langchain/langgraph";
 import { describe, expect, it } from "vitest";
 import type { AgentProgressEvent } from "@/lib/agent";
 import { createAgentService } from "@/lib/agent";
@@ -6,6 +7,8 @@ import { createFakeDockerClient } from "../../tests/support/fake-docker-client";
 import {
 	assistantText,
 	createScriptedAgentRunner,
+	toolCompleted,
+	toolStarted,
 } from "../../tests/support/scripted-agent-runner";
 import { createTempSessionDir } from "../../tests/support/temp-session-dir";
 import { createTestConfig } from "../../tests/support/test-config";
@@ -146,6 +149,50 @@ describe("agent service", () => {
 			expect.objectContaining({
 				type: "text-delta",
 				text: "Partial content before crash",
+			}),
+		]);
+	});
+
+	it("returns the recursion limit message and preserves tool calls when the graph exceeds max iterations", async () => {
+		await using tmp = await createTempSessionDir();
+		const runtime = createDockerRuntime(
+			createTestConfig({ rootDirectory: tmp.rootDirectory }),
+			{ client: createFakeDockerClient() },
+		);
+		const createRunner = createScriptedAgentRunner(async function* () {
+			yield toolStarted({
+				id: "tool-1",
+				input: { command: ["ls"] },
+				name: "run_command",
+			});
+			yield toolCompleted({
+				id: "tool-1",
+				name: "run_command",
+				output: "file.txt",
+			});
+			throw new GraphRecursionError(
+				"Recursion limit of 20 reached without hitting a stop condition",
+			);
+		});
+		const service = createAgentService({ createRunner, runtime });
+		const events: AgentProgressEvent[] = [];
+
+		const result = await service.streamConversation({
+			message: "do something complex",
+			sessionId: "session-a",
+			onEvent: (event) => {
+				events.push(event);
+			},
+		});
+
+		expect(result.content).toBe(
+			"The agent stopped because it kept chaining tool calls without reaching a final answer. I returned the tool timeline so you can see what it tried. The next fix is to tighten the prompt or the runtime instructions for this task.",
+		);
+		expect(result.toolCalls).toEqual([
+			expect.objectContaining({
+				id: "tool-1",
+				name: "run_command",
+				state: "completed",
 			}),
 		]);
 	});

--- a/apps/api/src/lib/sandbox/docker-runtime.test.ts
+++ b/apps/api/src/lib/sandbox/docker-runtime.test.ts
@@ -373,6 +373,67 @@ describe("createDockerRuntime", () => {
 		});
 	});
 
+	it("returns completed status when terminating an already-finished background command", async () => {
+		await using tmp = await createTempSessionDir();
+		let resolveCompletion = (_result: {
+			exitCode: number;
+			stderr: string;
+			stdout: string;
+		}) => {};
+		const completion = new Promise<{
+			exitCode: number;
+			stderr: string;
+			stdout: string;
+		}>((resolve) => {
+			resolveCompletion = resolve;
+		});
+
+		const client = createFakeDockerClient({
+			backgroundExecFixtures: [
+				{
+					command: ["some-task"],
+					completion,
+					result: {
+						exitCode: null,
+						stderr: "",
+						stdout: "started",
+					},
+					stdout: "task output\n",
+				},
+			],
+		});
+		const runtime = createDockerRuntime(
+			createTestConfig({ rootDirectory: tmp.rootDirectory }),
+			{ client },
+		);
+
+		const result = await runtime.runCommand("session-term", ["some-task"], {
+			keepAlive: true,
+			waitFor: "first-stdout-line",
+		});
+		const backgroundCommandId = result.backgroundCommandId;
+		assertDefined(backgroundCommandId);
+
+		resolveCompletion({ exitCode: 0, stderr: "", stdout: "task output\n" });
+		await runtime.waitForBackgroundCommand("session-term", backgroundCommandId);
+
+		const snapshot = await runtime.terminateBackgroundCommand(
+			"session-term",
+			backgroundCommandId,
+		);
+
+		expect(snapshot).toEqual({
+			command: ["some-task"],
+			endedAt: expect.any(String),
+			exitCode: 0,
+			id: backgroundCommandId,
+			startedAt: expect.any(String),
+			status: "completed",
+			stderr: "",
+			stdout: "task output\n",
+		});
+	});
+
 	it("destroys session resources including container and files", async () => {
 		await using tmp = await createTempSessionDir();
 		const client = createFakeDockerClient();

--- a/apps/api/src/routes/chat.test.ts
+++ b/apps/api/src/routes/chat.test.ts
@@ -31,6 +31,24 @@ describe("POST /api/chat", () => {
 		});
 	});
 
+	it("returns a validation error when the session-id header is missing", async () => {
+		const { createChatRoute } = await import("@/routes/chat");
+		const engine = createStubEngine();
+		const route = createChatRoute({ engine });
+
+		const response = await route(
+			new Request("http://localhost/api/chat", {
+				body: JSON.stringify({ message: "Hello" }),
+				headers: { "Content-Type": "application/json" },
+				method: "POST",
+			}),
+		);
+
+		expect(response.status).toBe(400);
+		const body = (await response.json()) as { errors: string[] };
+		expect(body.errors).toHaveLength(1);
+	});
+
 	it("returns a validation error when the message is empty", async () => {
 		const { createChatRoute } = await import("@/routes/chat");
 		const engine = createStubEngine();

--- a/apps/api/src/routes/session-events.test.ts
+++ b/apps/api/src/routes/session-events.test.ts
@@ -1,0 +1,62 @@
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import type { SessionStreamRegistry } from "@/lib/session-stream-registry";
+import { createSessionEventsRoute } from "./session-events";
+
+function createStubRegistry(
+	overrides: Partial<SessionStreamRegistry> = {},
+): SessionStreamRegistry {
+	return {
+		register: vi.fn(),
+		unregister: vi.fn(),
+		writeEvent: vi.fn(),
+		...overrides,
+	};
+}
+
+function createApp(registry: SessionStreamRegistry) {
+	const app = new Hono();
+	app.get("/api/sessions/:id/events", createSessionEventsRoute({ registry }));
+	return app;
+}
+
+describe("GET /api/sessions/:id/events", () => {
+	it("returns a validation error when the session id contains spaces", async () => {
+		const registry = createStubRegistry();
+		const app = createApp(registry);
+
+		const response = await app.request(
+			"/api/sessions/bad%20session%20id/events",
+		);
+
+		expect(response.status).toBe(400);
+		await expect(response.json()).resolves.toEqual({
+			errors: ["Missing or invalid sessionId."],
+		});
+	});
+
+	it("returns a validation error when the session id is empty", async () => {
+		const registry = createStubRegistry();
+		const app = createApp(registry);
+
+		const response = await app.request("/api/sessions/%20/events");
+
+		expect(response.status).toBe(400);
+		const body = (await response.json()) as { errors: string[] };
+		expect(body.errors).toContain("Missing or invalid sessionId.");
+	});
+
+	it("opens an SSE stream and registers the session on a valid request", async () => {
+		const registry = createStubRegistry();
+		const app = createApp(registry);
+
+		const response = await app.request("/api/sessions/session-123/events");
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-type")).toContain("text/event-stream");
+		expect(registry.register).toHaveBeenCalledWith(
+			"session-123",
+			expect.any(Object),
+		);
+	});
+});

--- a/apps/cli/src/auth/login.test.ts
+++ b/apps/cli/src/auth/login.test.ts
@@ -334,6 +334,60 @@ describe("auth login", () => {
 		});
 	});
 
+	it("returns a structured error when the user denies the device authorisation", async () => {
+		await using home = await createTempHome();
+		const stdout = createWritable(false);
+		const stderr = createWritable();
+		mswServer.use(
+			http.post(
+				"http://localhost:8180/realms/meridian/protocol/openid-connect/auth/device",
+				withFormBody(
+					{
+						client_id: "meridian-cli",
+						scope: "openid email profile",
+					},
+					() =>
+						HttpResponse.json({
+							device_code: "device-code",
+							user_code: "ABCD-1234",
+							verification_uri_complete:
+								"http://localhost:8180/device?user_code=ABCD-1234",
+							interval: 5,
+						}),
+				),
+			),
+			http.post(
+				"http://localhost:8180/realms/meridian/protocol/openid-connect/token",
+				withFormBody(
+					{
+						grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+						client_id: "meridian-cli",
+						device_code: "device-code",
+					},
+					() => HttpResponse.json({ error: "access_denied" }, { status: 400 }),
+				),
+			),
+		);
+
+		const exitCode = await runCli(["auth", "login", "--json"], {
+			env: {
+				MERIDIAN_AUTH_ISSUER: "http://localhost:8180/realms/meridian",
+				MERIDIAN_AUTH_CLIENT_ID: "meridian-cli",
+			},
+			homeDirectory: home.homeDirectory,
+			now: () => new Date("2026-03-06T12:00:00Z"),
+			sleep: async () => {},
+			stdout: stdout.stream,
+			stderr: stderr.stream,
+		});
+
+		expect(exitCode).toBe(1);
+		expect(stdout.output()).toContain('"status":"pending"');
+		expect(JSON.parse(stderr.output())).toEqual({
+			error: "access_denied",
+		});
+	});
+
 	it("returns a structured error when token polling has a transport failure", async () => {
 		await using home = await createTempHome();
 		const stdout = createWritable(false);

--- a/apps/cli/src/proposals/create.test.ts
+++ b/apps/cli/src/proposals/create.test.ts
@@ -227,6 +227,29 @@ describe("proposals create", () => {
 		expect(paymentTypes).toContain("OneTime");
 	});
 
+	it("errors when not authenticated", async () => {
+		await using home = await createTempHome();
+
+		const stdout = createWritable();
+		const stderr = createWritable();
+
+		const exitCode = await runCli(
+			["proposals", "create", "--proposal-request=pr-a1b2c3d4"],
+			{
+				homeDirectory: home.homeDirectory,
+				now: () => new Date("2026-03-06T16:20:05Z"),
+				stdout: stdout.stream,
+				stderr: stderr.stream,
+			},
+		);
+
+		expect(exitCode).toBe(1);
+		expect(stdout.output()).toBe("");
+		expect(stderr.output()).toContain(
+			'Not authenticated. Run "meridian auth login" first.',
+		);
+	});
+
 	it("errors when the proposal request does not exist", async () => {
 		await using home = await createTempHome();
 		await home.writeMeridianFile("credentials.json", {

--- a/apps/cli/src/results/get.test.ts
+++ b/apps/cli/src/results/get.test.ts
@@ -573,6 +573,77 @@ describe("results get", () => {
 		}
 	});
 
+	it("errors when not authenticated", async () => {
+		await using home = await createTempHome();
+		const stdout = createWritable(false);
+		const stderr = createWritable();
+
+		const exitCode = await runCli(
+			["results", "get", "--proposal=prop-any", "--json"],
+			{
+				homeDirectory: home.homeDirectory,
+				now: () => new Date("2026-03-07T16:00:00Z"),
+				stdout: stdout.stream,
+				stderr: stderr.stream,
+			},
+		);
+
+		expect(exitCode).toBe(1);
+		expect(stdout.output()).toBe("");
+		expect(JSON.parse(stderr.output())).toEqual({
+			error: 'Not authenticated. Run "meridian auth login" first.',
+		});
+	});
+
+	it("errors when the proposal exists but the result does not", async () => {
+		await using home = await createTempHome();
+		await home.writeMeridianFile("credentials.json", {
+			accessToken: "access-token",
+			user: "john.doe@example.com",
+			expiresAt: "2026-03-07T16:20:00Z",
+		});
+		await home.writeMeridianFile("data.json", {
+			proposalRequests: {
+				"pr-a1b2c3d4": {
+					product: "broadband",
+					version: "1.0",
+					emailAddress: "john.doe@example.com",
+					data: { postcode: "AA1 1AA" },
+					createdAt: "2026-03-06T16:20:00.000Z",
+				},
+			},
+			proposals: {
+				"prop-x7y8z9": {
+					proposalRequestId: "pr-a1b2c3d4",
+					product: "broadband",
+					version: "1.0",
+					status: "completed",
+					createdAt: "2026-03-06T16:20:05.000Z",
+				},
+			},
+			results: {},
+		});
+
+		const stdout = createWritable(false);
+		const stderr = createWritable();
+
+		const exitCode = await runCli(
+			["results", "get", "--proposal=prop-x7y8z9", "--json"],
+			{
+				homeDirectory: home.homeDirectory,
+				now: () => new Date("2026-03-07T16:00:00Z"),
+				stdout: stdout.stream,
+				stderr: stderr.stream,
+			},
+		);
+
+		expect(exitCode).toBe(1);
+		expect(stdout.output()).toBe("");
+		expect(JSON.parse(stderr.output())).toEqual({
+			error: 'Result for proposal "prop-x7y8z9" not found.',
+		});
+	});
+
 	it("returns a structured error when the local data store is corrupted", async () => {
 		await using home = await createTempHome();
 		await home.writeMeridianFile("credentials.json", {


### PR DESCRIPTION
## Summary

- Adds 10 missing tests identified during a test suite audit of `@meridian/cli` and `@meridian/api`
- Fills gaps in untested error paths, validation branches, and edge cases
- No changes to production code

### CLI (4 tests)
- `auth login`: device flow denied by user (`access_denied` from token endpoint)
- `proposals create`: not authenticated (no credentials)
- `results get`: not authenticated (no credentials)
- `results get`: proposal exists but result does not (separate error branch)

### API (6 tests)
- `GET /api/sessions/:id/events`: validation for invalid and empty session IDs, SSE stream registration on valid request (previously **zero** test coverage on this endpoint)
- `POST /api/chat`: missing `session-id` header entirely
- Agent service: `GraphRecursionError` returns the recursion limit message with tool calls preserved
- Docker runtime: terminating an already-completed background command preserves its `completed` status

## Test plan
- [x] `pnpm test` passes across all packages (297 tests)
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)