### PR TITLE
ci: add PR conventions check agent

### DIFF
--- a/.github/workflows/conventions-check.yml
+++ b/.github/workflows/conventions-check.yml
@@ -1,0 +1,31 @@
+name: Conventions Check
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run conventions check
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node scripts/conventions-agent/check.ts

--- a/.github/workflows/conventions-check.yml
+++ b/.github/workflows/conventions-check.yml
@@ -16,8 +16,6 @@ jobs:
           node-version: "24"
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"*.{ts,tsx,json,mjs}": "biome check --write --no-errors-on-unmatched"
 	},
 	"devDependencies": {
+		"@anthropic-ai/claude-agent-sdk": "^0.2.79",
 		"@biomejs/biome": "^2.4.6",
 		"@commitlint/cli": "^20.4.4",
 		"@commitlint/config-conventional": "^20.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.2.79
+        version: 0.2.79(zod@4.3.6)
       '@biomejs/biome':
         specifier: ^2.4.6
         version: 2.4.6
@@ -177,6 +180,12 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@anthropic-ai/claude-agent-sdk@0.2.79':
+    resolution: {integrity: sha512-4HmjT2pzjcYSXGxe18L0D1+5GEak3bk25C2H9GlKFnOeCkYAHG4cla4U/rn+v+S2Ecv5m/hsNQ1hDbzg4Ns7rA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -2525,6 +2534,20 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@anthropic-ai/claude-agent-sdk@0.2.79(zod@4.3.6)':
+    dependencies:
+      zod: 4.3.6
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   '@babel/code-frame@7.29.0':
     dependencies:

--- a/scripts/conventions-agent/check.ts
+++ b/scripts/conventions-agent/check.ts
@@ -1,0 +1,207 @@
+/**
+ * Conventions check agent.
+ *
+ * Reads a PR diff, explores the codebase for established patterns,
+ * and returns a structured list of convention violations.
+ *
+ * Designed to run both in CI (GitHub Actions) and locally for testing.
+ *
+ * Usage (CI):  node examples/pr-conventions-agent/check.ts
+ *   Expects: PR_NUMBER, REPO, BASE_BRANCH env vars
+ *
+ * Usage (local test): node examples/pr-conventions-agent/check.ts --repo owner/repo --pr 42
+ */
+
+import { randomUUID } from "node:crypto";
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import {
+	findReviewComment,
+	formatComment,
+	getPrDiff,
+	postComment,
+	updateComment,
+} from "./github.ts";
+import { DEFAULT_CONFIG, type Finding } from "./types.ts";
+
+const FINDINGS_SCHEMA = {
+	type: "object" as const,
+	properties: {
+		findings: {
+			type: "array" as const,
+			items: {
+				type: "object" as const,
+				properties: {
+					title: {
+						type: "string" as const,
+						description:
+							"Short summary, e.g. 'Use the API client instead of raw fetch'",
+					},
+					description: {
+						type: "string" as const,
+						description:
+							"Explanation of the violation and what the convention is",
+					},
+					violation: {
+						type: "object" as const,
+						properties: {
+							path: { type: "string" as const },
+							startLine: { type: "number" as const },
+							endLine: { type: "number" as const },
+						},
+						required: ["path", "startLine", "endLine"] as const,
+					},
+					conventionExample: {
+						type: "object" as const,
+						properties: {
+							path: { type: "string" as const },
+							startLine: { type: "number" as const },
+							endLine: { type: "number" as const },
+						},
+						required: ["path", "startLine", "endLine"] as const,
+					},
+				},
+				required: [
+					"title",
+					"description",
+					"violation",
+					"conventionExample",
+				] as const,
+			},
+		},
+	},
+	required: ["findings"] as const,
+};
+
+type FindingsOutput = {
+	findings: Array<{
+		title: string;
+		description: string;
+		violation: { path: string; startLine: number; endLine: number };
+		conventionExample: { path: string; startLine: number; endLine: number };
+	}>;
+};
+
+function buildPrompt(diff: string, maxFindings: number): string {
+	return `You are a codebase conventions checker. Your job is to find places where the PR diff below diverges from established patterns and conventions in the existing codebase.
+
+## Instructions
+
+1. Read the diff carefully to understand what was changed.
+2. For each pattern you see in the diff (imports, utilities, naming, file structure, error handling, test patterns), use Glob and Grep to search the codebase for how those same things are done elsewhere.
+3. If the PR does something differently from the clear majority pattern in the codebase, flag it.
+4. For each finding, reference BOTH where the violation is AND a concrete example of the convention elsewhere.
+5. If a convention file (.conventions) exists at the repo root, read it for additional hints.
+
+## Rules
+
+- Only flag clear convention violations where the codebase has a strong majority pattern.
+- Do NOT flag things where the codebase is split 50/50.
+- Do NOT flag general code quality, performance, or security issues.
+- Do NOT flag style/formatting (that's what linters are for).
+- Be specific about file paths and line numbers.
+- Maximum ${maxFindings} findings.
+
+## PR Diff
+
+\`\`\`diff
+${diff}
+\`\`\`
+
+Analyse the diff, explore the codebase, and return your findings.`;
+}
+
+/** Parse CLI args for local testing. */
+function parseArgs(): { repo: string; prNumber: number } {
+	const args = process.argv.slice(2);
+	let repo = process.env.REPO ?? "";
+	let prNumber = Number(process.env.PR_NUMBER ?? 0);
+
+	for (let i = 0; i < args.length; i++) {
+		if (args[i] === "--repo" && args[i + 1]) repo = args[++i];
+		if (args[i] === "--pr" && args[i + 1]) prNumber = Number(args[++i]);
+	}
+
+	if (!repo || !prNumber) {
+		console.error("Usage: node check.ts --repo owner/repo --pr 42");
+		console.error("  Or set REPO and PR_NUMBER env vars.");
+		process.exit(1);
+	}
+
+	return { repo, prNumber };
+}
+
+async function main() {
+	const { repo, prNumber } = parseArgs();
+	const config = DEFAULT_CONFIG;
+
+	console.log(`Checking conventions for ${repo}#${prNumber}...`);
+
+	// Get the PR diff
+	const diff = await getPrDiff(repo, prNumber);
+	if (!diff) {
+		console.log("Empty diff — nothing to check.");
+		process.exit(0);
+	}
+
+	// Run the conventions check agent
+	const prompt = buildPrompt(diff, config.maxFindingsPerCheck);
+	let structuredOutput: unknown;
+
+	for await (const msg of query({
+		prompt,
+		options: {
+			model: config.model,
+			allowedTools: ["Read", "Glob", "Grep"],
+			permissionMode: "dontAsk",
+			outputFormat: { type: "json_schema", schema: FINDINGS_SCHEMA },
+		},
+	})) {
+		if (msg.type === "result" && msg.subtype === "success") {
+			structuredOutput = msg.structured_output;
+			console.log(
+				`Check complete (${msg.num_turns} turns, $${msg.total_cost_usd.toFixed(4)})`,
+			);
+		}
+	}
+
+	if (!structuredOutput) {
+		console.error("Agent did not return structured output.");
+		process.exit(1);
+	}
+
+	const output = structuredOutput as FindingsOutput;
+	const findings: Finding[] = output.findings.map((f) => ({
+		id: randomUUID().slice(0, 8),
+		...f,
+		selected: false,
+		implemented: false,
+	}));
+
+	console.log(`Found ${findings.length} convention violation(s).`);
+
+	// Post or update the PR comment
+	const reviewId = randomUUID().slice(0, 8);
+	const commentBody = formatComment(reviewId, findings);
+
+	const existing = await findReviewComment(repo, prNumber);
+	if (existing) {
+		await updateComment(repo, existing.commentId, commentBody);
+		console.log(`Updated existing comment #${existing.commentId}`);
+	} else {
+		const commentId = await postComment(repo, prNumber, commentBody);
+		console.log(`Posted comment #${commentId}`);
+	}
+
+	// Exit with failure if there are findings (blocks merge as a required check)
+	if (findings.length > 0) {
+		console.log("CI check failed — convention violations found.");
+		process.exit(1);
+	}
+
+	console.log("CI check passed — no convention violations.");
+}
+
+main().catch((err) => {
+	console.error("Conventions check failed:", err);
+	process.exit(1);
+});

--- a/scripts/conventions-agent/github.ts
+++ b/scripts/conventions-agent/github.ts
@@ -1,0 +1,179 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { Finding } from "./types.ts";
+
+const exec = promisify(execFile);
+
+/** Run a gh CLI command and return stdout. */
+async function gh(...args: string[]): Promise<string> {
+	const { stdout } = await exec("gh", args);
+	return stdout.trim();
+}
+
+/** Get the diff for a PR against its base branch. */
+export async function getPrDiff(
+	repo: string,
+	prNumber: number,
+): Promise<string> {
+	return gh("pr", "diff", String(prNumber), "--repo", repo);
+}
+
+/** Check if a PR is still open. */
+export async function isPrOpen(
+	repo: string,
+	prNumber: number,
+): Promise<boolean> {
+	const state = await gh(
+		"pr",
+		"view",
+		String(prNumber),
+		"--repo",
+		repo,
+		"--json",
+		"state",
+		"--jq",
+		".state",
+	);
+	return state === "OPEN";
+}
+
+/** Get the clone URL for a repo. */
+export async function getCloneUrl(repo: string): Promise<string> {
+	const url = await gh(
+		"repo",
+		"view",
+		repo,
+		"--json",
+		"sshUrl",
+		"--jq",
+		".sshUrl",
+	);
+	return url;
+}
+
+/** Format findings into the checkbox markdown comment. */
+export function formatComment(reviewId: string, findings: Finding[]): string {
+	if (findings.length === 0) {
+		return [
+			"## Conventions Check",
+			"",
+			"This PR follows the existing codebase conventions. No issues found.",
+			"",
+			`<!-- agent:review-id:${reviewId} -->`,
+		].join("\n");
+	}
+
+	const items = findings.map((f) => {
+		const location = `\`${f.violation.path}:${f.violation.startLine}\``;
+		const example = `\`${f.conventionExample.path}:${f.conventionExample.startLine}\``;
+		return `- [ ] **${f.title}** (${location})\n  ${f.description} See ${example} for an example.`;
+	});
+
+	return [
+		"## Conventions Check",
+		"",
+		"I've checked this PR against the existing codebase patterns. The following are inconsistent with established conventions:",
+		"",
+		...items,
+		"",
+		"---",
+		"*Fix these manually or tick the checkboxes and reply `/go` to apply fixes automatically.*",
+		`<!-- agent:review-id:${reviewId} -->`,
+	].join("\n");
+}
+
+/** Post a comment on a PR. Returns the comment ID. */
+export async function postComment(
+	repo: string,
+	prNumber: number,
+	body: string,
+): Promise<number> {
+	const result = await gh(
+		"pr",
+		"comment",
+		String(prNumber),
+		"--repo",
+		repo,
+		"--body",
+		body,
+	);
+	// gh pr comment prints the URL — extract the comment ID from it
+	const match = result.match(/#issuecomment-(\d+)/);
+	if (match) return Number(match[1]);
+
+	// Fallback: fetch the latest comment to get its ID
+	const comments = await gh(
+		"api",
+		`repos/${repo}/issues/${prNumber}/comments`,
+		"--jq",
+		".[-1].id",
+	);
+	return Number(comments);
+}
+
+/** Update an existing comment. */
+export async function updateComment(
+	repo: string,
+	commentId: number,
+	body: string,
+): Promise<void> {
+	await gh(
+		"api",
+		`repos/${repo}/issues/comments/${commentId}`,
+		"--method",
+		"PATCH",
+		"--field",
+		`body=${body}`,
+	);
+}
+
+/** Post a reply comment on a PR. */
+export async function postReply(
+	repo: string,
+	prNumber: number,
+	body: string,
+): Promise<void> {
+	await gh("pr", "comment", String(prNumber), "--repo", repo, "--body", body);
+}
+
+/** Get all comments on a PR to find the agent's review comment. */
+export async function findReviewComment(
+	repo: string,
+	prNumber: number,
+): Promise<{ commentId: number; body: string; reviewId: string } | null> {
+	const commentsJson = await gh(
+		"api",
+		`repos/${repo}/issues/${prNumber}/comments`,
+		"--jq",
+		"[.[] | {id: .id, body: .body}]",
+	);
+	const comments: { id: number; body: string }[] = JSON.parse(commentsJson);
+
+	for (const comment of comments) {
+		const match = comment.body.match(/<!-- agent:review-id:(\w+) -->/);
+		if (match) {
+			return {
+				commentId: comment.id,
+				body: comment.body,
+				reviewId: match[1],
+			};
+		}
+	}
+	return null;
+}
+
+/** Parse checked items from the markdown comment body. */
+export function parseCheckedItems(body: string): string[] {
+	const regex = /- \[x\] \*\*(.+?)\*\*/gi;
+	return Array.from(body.matchAll(regex), (m) => m[1]);
+}
+
+/** Clone a repo to a target directory and checkout a branch. */
+export async function cloneAndCheckout(
+	repo: string,
+	branch: string,
+	targetDir: string,
+): Promise<void> {
+	const cloneUrl = await getCloneUrl(repo);
+	await exec("git", ["clone", "--branch", branch, cloneUrl, targetDir]);
+}

--- a/scripts/conventions-agent/types.ts
+++ b/scripts/conventions-agent/types.ts
@@ -1,0 +1,49 @@
+export type Finding = {
+	id: string;
+	title: string;
+	description: string;
+	violation: {
+		path: string;
+		startLine: number;
+		endLine: number;
+	};
+	conventionExample: {
+		path: string;
+		startLine: number;
+		endLine: number;
+	};
+	selected: boolean;
+	implemented: boolean;
+};
+
+export type ReviewJob = {
+	id: string;
+	repo: string;
+	prNumber: number;
+	headBranch: string;
+	baseBranch: string;
+	commentId: number;
+	findings: Finding[];
+	status: "implementing" | "done" | "error";
+	createdAt: string;
+	updatedAt: string;
+	error?: string;
+};
+
+export type AgentConfig = {
+	githubWebhookSecret: string;
+	model: string;
+	maxFindingsPerCheck: number;
+	workDir: string;
+	dataDir: string;
+	port: number;
+};
+
+export const DEFAULT_CONFIG: AgentConfig = {
+	githubWebhookSecret: process.env.GITHUB_WEBHOOK_SECRET ?? "",
+	model: "claude-sonnet-4-6",
+	maxFindingsPerCheck: 10,
+	workDir: process.env.WORK_DIR ?? "/tmp/pr-conventions-work",
+	dataDir: process.env.DATA_DIR ?? ".data",
+	port: Number(process.env.PORT ?? 3000),
+};


### PR DESCRIPTION
## Summary

- Adds a CI job that runs on every PR push to check for codebase convention violations
- Uses the Claude Agent SDK to analyse the diff, explore the existing codebase for established patterns, and flag inconsistencies
- Posts findings as a checkbox comment on the PR and fails the check if violations are found, blocking merge until resolved

## Files

- `.github/workflows/conventions-check.yml` — GitHub Actions workflow
- `scripts/conventions-agent/check.ts` — conventions check agent
- `scripts/conventions-agent/github.ts` — GitHub API helpers
- `scripts/conventions-agent/types.ts` — shared types

## Test plan

- [ ] Open a PR with a deliberate convention violation and verify the CI job catches it
- [ ] Verify the CI job passes when no violations are found

🤖 Generated with [Claude Code](https://claude.com/claude-code)